### PR TITLE
[RFC] Allow returning empty reservation

### DIFF
--- a/ni_measurementlink_service/session_management/_reservation.py
+++ b/ni_measurementlink_service/session_management/_reservation.py
@@ -741,11 +741,6 @@ class BaseReservation(_BaseSessionContainer):
         if not instrument_type_id:
             raise ValueError("This method requires an instrument type ID.")
         session_infos = self._get_matching_session_infos(instrument_type_id)
-        if len(session_infos) == 0:
-            raise ValueError(
-                f"No reserved sessions matched instrument type ID '{instrument_type_id}'. "
-                "Expected single or multiple sessions, got 0 sessions."
-            )
 
         if closing_function is None:
             closing_function = closing_session

--- a/tests/unit/test_reservation.py
+++ b/tests/unit/test_reservation.py
@@ -180,11 +180,8 @@ def test___no_session_infos___initialize_sessions___value_error_raised(
 ) -> None:
     reservation = MultiSessionReservation(session_management_client, [])
 
-    with pytest.raises(ValueError) as exc_info:
-        with reservation.initialize_sessions(construct_session, "nifake"):
-            pass
-
-    assert "No reserved sessions matched instrument type ID 'nifake'." in exc_info.value.args[0]
+    with reservation.initialize_sessions(construct_session, "nifake") as reserved_sessions:
+        assert reserved_sessions == []
 
 
 def test___session_already_exists___initialize_sessions___runtime_error_raised(


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

No longer error when `_initialize_sessions_core` is called and no session_info matches the instrument type id. Instead just return an empty array.
 
### Why should this Pull Request be merged?

For DAQmx measurements in TestStand using the I/O Discovery Service, we will rely on the measurement to create the session/tasks. This is because without a pin map, we can't know ahead of time what to create.

One fix for this is to address it in the example code. That exists change is proposed here:  #736
It was suggested to address this in the framework instead.

We should also decide if we want the single ` _initialize_session_core` to behave the same or not.

### What testing has been done?

Fixed automated test. Still need to test with sequence and I/O Discovery service.