### PR TITLE
example: game_of_life: remove the second incrementation of generation variable

### DIFF
--- a/examples/game_of_life/measurement.py
+++ b/examples/game_of_life/measurement.py
@@ -56,7 +56,6 @@ def measure(
             row_index += 1
         grid = _update_grid(grid)
         xydata_out = xydata
-        generation += 1
         delay = max(0.0, update_interval_sec - (time.monotonic() - iteration_start_time))
         yield (xydata_out, generation)
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?
Removes the second incrementation of the `generation` variable.

### Why should this Pull Request be merged?
The `generation` variable is mistakenly incremented twice within the while loop.

### What testing has been done?
Kept a breakpoint and verified that the generation value is incremented only once per iteration.