### PR TITLE
Add .serviceignore files to the examples

### DIFF
--- a/examples/game_of_life/.serviceignore
+++ b/examples/game_of_life/.serviceignore
@@ -1,0 +1,4 @@
+# This file specifies that when we publish this plugin to a Plug-in Library,
+# we should not copy the following directories:
+.venv
+__pycache__

--- a/examples/nidaqmx_analog_input/.serviceignore
+++ b/examples/nidaqmx_analog_input/.serviceignore
@@ -1,0 +1,4 @@
+# This file specifies that when we publish this plugin to a Plug-in Library,
+# we should not copy the following directories:
+.venv
+__pycache__

--- a/examples/nidcpower_source_dc_voltage/.serviceignore
+++ b/examples/nidcpower_source_dc_voltage/.serviceignore
@@ -1,0 +1,4 @@
+# This file specifies that when we publish this plugin to a Plug-in Library,
+# we should not copy the following directories:
+.venv
+__pycache__

--- a/examples/nidcpower_source_dc_voltage_with_multiplexer/.serviceignore
+++ b/examples/nidcpower_source_dc_voltage_with_multiplexer/.serviceignore
@@ -1,0 +1,4 @@
+# This file specifies that when we publish this plugin to a Plug-in Library,
+# we should not copy the following directories:
+.venv
+__pycache__

--- a/examples/nidigital_spi/.serviceignore
+++ b/examples/nidigital_spi/.serviceignore
@@ -1,0 +1,4 @@
+# This file specifies that when we publish this plugin to a Plug-in Library,
+# we should not copy the following directories:
+.venv
+__pycache__

--- a/examples/nidmm_measurement/.serviceignore
+++ b/examples/nidmm_measurement/.serviceignore
@@ -1,0 +1,4 @@
+# This file specifies that when we publish this plugin to a Plug-in Library,
+# we should not copy the following directories:
+.venv
+__pycache__

--- a/examples/nifgen_standard_function/.serviceignore
+++ b/examples/nifgen_standard_function/.serviceignore
@@ -1,0 +1,4 @@
+# This file specifies that when we publish this plugin to a Plug-in Library,
+# we should not copy the following directories:
+.venv
+__pycache__

--- a/examples/niscope_acquire_waveform/.serviceignore
+++ b/examples/niscope_acquire_waveform/.serviceignore
@@ -1,0 +1,4 @@
+# This file specifies that when we publish this plugin to a Plug-in Library,
+# we should not copy the following directories:
+.venv
+__pycache__

--- a/examples/niswitch_control_relays/.serviceignore
+++ b/examples/niswitch_control_relays/.serviceignore
@@ -1,0 +1,4 @@
+# This file specifies that when we publish this plugin to a Plug-in Library,
+# we should not copy the following directories:
+.venv
+__pycache__

--- a/examples/nivisa_dmm_measurement/.serviceignore
+++ b/examples/nivisa_dmm_measurement/.serviceignore
@@ -1,0 +1,4 @@
+# This file specifies that when we publish this plugin to a Plug-in Library,
+# we should not copy the following directories:
+.venv
+__pycache__

--- a/examples/output_voltage_measurement/.serviceignore
+++ b/examples/output_voltage_measurement/.serviceignore
@@ -1,0 +1,4 @@
+# This file specifies that when we publish this plugin to a Plug-in Library,
+# we should not copy the following directories:
+.venv
+__pycache__

--- a/examples/sample_measurement/.serviceignore
+++ b/examples/sample_measurement/.serviceignore
@@ -1,0 +1,4 @@
+# This file specifies that when we publish this plugin to a Plug-in Library,
+# we should not copy the following directories:
+.venv
+__pycache__


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

This PR adds `.serviceignore` files to each of the examples in preparation of the Plug-in Library release.

### Why should this Pull Request be merged?

When publishing a plugin to a Plug-in Library, we should exclude the `.venv` folder and the `__pycache__` folder if they are present.  The presence of the `.serviceignore` file will instruct the Plug-in Library CLI to ignore these folders.

### What testing has been done?

Verified that when publishing one of the examples to a Plug-in Library, we ignore these two folders.

**Note**
This PR should not be completed prior to the upcoming release of Plug-in Library.