### PR TITLE
Fix ReadTheDocs build by including working directory for post-install

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,7 +10,7 @@ build:
       # Tell poetry to not use a virtual environment
       - poetry config virtualenvs.create false
     post_install:
-      - pushd packages/service/ && poetry install --with docs
+      - poetry -C packages/service/ install --with docs
 
 sphinx:
   configuration: packages/service/_docs_source/conf.py

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,6 +11,7 @@ build:
       - poetry config virtualenvs.create false
     post_install:
       - poetry install --with docs
+      working-directory: packages/service
 
 sphinx:
   configuration: packages/service/_docs_source/conf.py

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,10 +7,8 @@ build:
   jobs:
     post_create_environment:
       - pip install poetry==1.8.2
-      # Tell poetry to not use a virtual environment
-      - poetry config virtualenvs.create false
     post_install:
-      - poetry -C packages/service/ install --with docs
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry -C packages/service/ install --with docs
 
 sphinx:
   configuration: packages/service/_docs_source/conf.py

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,8 +10,7 @@ build:
       # Tell poetry to not use a virtual environment
       - poetry config virtualenvs.create false
     post_install:
-      - poetry install --with docs
-      working-directory: packages/service
+      - pushd packages/service/ && poetry install --with docs
 
 sphinx:
   configuration: packages/service/_docs_source/conf.py


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

ReadTheDocs build is failing because it is not finding pyproject.toml at the root directory:
https://readthedocs.org/projects/measurement-plugin-python/builds/24965585/

### Why should this Pull Request be merged?

Fix the docs build

### What testing has been done?

None. Will look at the RTD build after submission.