### PR TITLE
Add Plug-in Library installs scripts to the examples

### DIFF
--- a/examples/game_of_life/game_of_life.serviceconfig
+++ b/examples/game_of_life/game_of_life.serviceconfig
@@ -8,6 +8,7 @@
         "ni.measurementlink.measurement.v2.MeasurementService"
       ],
       "path": "start.bat",
+      "installPath": "install.bat",
       "annotations": {
         "ni/service.description": "Measurement plug-in example that displays Conway's Game of Life simulation in a graph.",
         "ni/service.collection": "NI.Examples",

--- a/examples/game_of_life/install.bat
+++ b/examples/game_of_life/install.bat
@@ -1,0 +1,6 @@
+@echo off
+REM The discovery service uses this script to install the dependencies
+REM for the measurement service. You can customize this script for your
+REM Python setup.
+
+poetry install --only main

--- a/examples/nidaqmx_analog_input/NIDAQmxAnalogInput.serviceconfig
+++ b/examples/nidaqmx_analog_input/NIDAQmxAnalogInput.serviceconfig
@@ -9,6 +9,7 @@
         "ni.measurementlink.measurement.v2.MeasurementService"
       ],
       "path": "start.bat",
+      "installPath": "install.bat",
       "annotations": {
         "ni/service.description": "Measurement plug-in example that performs a finite analog input measurement with NI-DAQmx.",
         "ni/service.collection": "NI.Examples",

--- a/examples/nidaqmx_analog_input/install.bat
+++ b/examples/nidaqmx_analog_input/install.bat
@@ -1,0 +1,6 @@
+@echo off
+REM The discovery service uses this script to install the dependencies
+REM for the measurement service. You can customize this script for your
+REM Python setup.
+
+poetry install --only main

--- a/examples/nidcpower_source_dc_voltage/NIDCPowerSourceDCVoltage.serviceconfig
+++ b/examples/nidcpower_source_dc_voltage/NIDCPowerSourceDCVoltage.serviceconfig
@@ -9,6 +9,7 @@
         "ni.measurementlink.measurement.v2.MeasurementService"
       ],
       "path": "start.bat",
+      "installPath": "install.bat",
       "annotations": {
         "ni/service.description": "Measurement plug-in example that sources and measures a DC voltage with an NI SMU.",
         "ni/service.collection": "NI.Examples",

--- a/examples/nidcpower_source_dc_voltage/install.bat
+++ b/examples/nidcpower_source_dc_voltage/install.bat
@@ -1,0 +1,6 @@
+@echo off
+REM The discovery service uses this script to install the dependencies
+REM for the measurement service. You can customize this script for your
+REM Python setup.
+
+poetry install --only main

--- a/examples/nidcpower_source_dc_voltage_with_multiplexer/NIDCPowerSourceDCVoltageWithMultiplexer.serviceconfig
+++ b/examples/nidcpower_source_dc_voltage_with_multiplexer/NIDCPowerSourceDCVoltageWithMultiplexer.serviceconfig
@@ -9,6 +9,7 @@
         "ni.measurementlink.measurement.v2.MeasurementService"
       ],
       "path": "start.bat",
+      "installPath": "install.bat",
       "annotations": {
         "ni/service.description": "Measurement plug-in example that sources and measures a DC voltage with an NI SMU via an NI-SWITCH multiplexer.",
         "ni/service.collection": "NI.Examples",

--- a/examples/nidcpower_source_dc_voltage_with_multiplexer/install.bat
+++ b/examples/nidcpower_source_dc_voltage_with_multiplexer/install.bat
@@ -1,0 +1,6 @@
+@echo off
+REM The discovery service uses this script to install the dependencies
+REM for the measurement service. You can customize this script for your
+REM Python setup.
+
+poetry install --only main

--- a/examples/nidigital_spi/NIDigitalSPI.serviceconfig
+++ b/examples/nidigital_spi/NIDigitalSPI.serviceconfig
@@ -9,6 +9,7 @@
         "ni.measurementlink.measurement.v2.MeasurementService"
       ],
       "path": "start.bat",
+      "installPath": "install.bat",
       "annotations": {
         "ni/service.description": "Measurement plug-in example that tests a SPI device using an NI Digital Pattern instrument.",
         "ni/service.collection": "NI.Examples",

--- a/examples/nidigital_spi/install.bat
+++ b/examples/nidigital_spi/install.bat
@@ -1,0 +1,6 @@
+@echo off
+REM The discovery service uses this script to install the dependencies
+REM for the measurement service. You can customize this script for your
+REM Python setup.
+
+poetry install --only main

--- a/examples/nidmm_measurement/NIDmmMeasurement.serviceconfig
+++ b/examples/nidmm_measurement/NIDmmMeasurement.serviceconfig
@@ -9,6 +9,7 @@
         "ni.measurementlink.measurement.v2.MeasurementService"
       ],
       "path": "start.bat",
+      "installPath": "install.bat",
       "annotations": {
         "ni/service.description": "Measurement plug-in example that performs a measurement using an NI DMM.",
         "ni/service.collection": "NI.Examples",

--- a/examples/nidmm_measurement/install.bat
+++ b/examples/nidmm_measurement/install.bat
@@ -1,0 +1,6 @@
+@echo off
+REM The discovery service uses this script to install the dependencies
+REM for the measurement service. You can customize this script for your
+REM Python setup.
+
+poetry install --only main

--- a/examples/nifgen_standard_function/NIFgenStandardFunction.serviceconfig
+++ b/examples/nifgen_standard_function/NIFgenStandardFunction.serviceconfig
@@ -9,6 +9,7 @@
         "ni.measurementlink.measurement.v2.MeasurementService"
       ],
       "path": "start.bat",
+      "installPath": "install.bat",
       "annotations": {
         "ni/service.description": "Measurement plug-in example that generates a standard function waveform using an NI waveform generator.",
         "ni/service.collection": "NI.Examples",

--- a/examples/nifgen_standard_function/install.bat
+++ b/examples/nifgen_standard_function/install.bat
@@ -1,0 +1,6 @@
+@echo off
+REM The discovery service uses this script to install the dependencies
+REM for the measurement service. You can customize this script for your
+REM Python setup.
+
+poetry install --only main

--- a/examples/niscope_acquire_waveform/NIScopeAcquireWaveform.serviceconfig
+++ b/examples/niscope_acquire_waveform/NIScopeAcquireWaveform.serviceconfig
@@ -9,6 +9,7 @@
         "ni.measurementlink.measurement.v2.MeasurementService"
       ],
       "path": "start.bat",
+      "installPath": "install.bat",
       "annotations": {
         "ni/service.description": "Measurement plug-in example that acquires a waveform using an NI oscilloscope.",
         "ni/service.collection": "NI.Examples",

--- a/examples/niscope_acquire_waveform/install.bat
+++ b/examples/niscope_acquire_waveform/install.bat
@@ -1,0 +1,6 @@
+@echo off
+REM The discovery service uses this script to install the dependencies
+REM for the measurement service. You can customize this script for your
+REM Python setup.
+
+poetry install --only main

--- a/examples/niswitch_control_relays/NISwitchControlRelays.serviceconfig
+++ b/examples/niswitch_control_relays/NISwitchControlRelays.serviceconfig
@@ -9,6 +9,7 @@
         "ni.measurementlink.measurement.v2.MeasurementService"
       ],
       "path": "start.bat",
+      "installPath": "install.bat",
       "annotations": {
         "ni/service.description": "Measurement plug-in example that controls relays using an NI relay driver (e.g. PXI-2567).",
         "ni/service.collection": "NI.Examples",

--- a/examples/niswitch_control_relays/install.bat
+++ b/examples/niswitch_control_relays/install.bat
@@ -1,0 +1,6 @@
+@echo off
+REM The discovery service uses this script to install the dependencies
+REM for the measurement service. You can customize this script for your
+REM Python setup.
+
+poetry install --only main

--- a/examples/nivisa_dmm_measurement/NIVisaDmmMeasurement.serviceconfig
+++ b/examples/nivisa_dmm_measurement/NIVisaDmmMeasurement.serviceconfig
@@ -9,6 +9,7 @@
         "ni.measurementlink.measurement.v2.MeasurementService"
       ],
       "path": "start.bat",
+      "installPath": "install.bat",
       "annotations": {
         "ni/service.description": "Measurement plug-in example that performs a DMM measurement using NI-VISA and an NI Instrument Simulator v2.0.",
         "ni/service.collection": "NI.Examples",

--- a/examples/nivisa_dmm_measurement/install.bat
+++ b/examples/nivisa_dmm_measurement/install.bat
@@ -1,0 +1,6 @@
+@echo off
+REM The discovery service uses this script to install the dependencies
+REM for the measurement service. You can customize this script for your
+REM Python setup.
+
+poetry install --only main

--- a/examples/output_voltage_measurement/OutputVoltageMeasurement.serviceconfig
+++ b/examples/output_voltage_measurement/OutputVoltageMeasurement.serviceconfig
@@ -9,6 +9,7 @@
         "ni.measurementlink.measurement.v2.MeasurementService"
       ],
       "path": "start.bat",
+      "installPath": "install.bat",
       "annotations": {
         "ni/service.description": "Source DC voltage as input with an NI SMU and measure output using NI-VISA DMM and an NI Instrument Simulator v2.0.",
         "ni/service.collection": "NI.Examples",

--- a/examples/output_voltage_measurement/install.bat
+++ b/examples/output_voltage_measurement/install.bat
@@ -1,0 +1,6 @@
+@echo off
+REM The discovery service uses this script to install the dependencies
+REM for the measurement service. You can customize this script for your
+REM Python setup.
+
+poetry install --only main

--- a/examples/sample_measurement/SampleMeasurement.serviceconfig
+++ b/examples/sample_measurement/SampleMeasurement.serviceconfig
@@ -9,12 +9,12 @@
         "ni.measurementlink.measurement.v2.MeasurementService"
       ],
       "path": "start.bat",
+      "installPath": "install.bat",
       "annotations": {
         "ni/service.description": "Measurement plug-in example that performs a loopback measurement with various data types.",
         "ni/service.collection": "NI.Examples",
         "ni/service.tags": []
       }
-
     }
   ]
 }

--- a/examples/sample_measurement/install.bat
+++ b/examples/sample_measurement/install.bat
@@ -1,0 +1,6 @@
+@echo off
+REM The discovery service uses this script to install the dependencies
+REM for the measurement service. You can customize this script for your
+REM Python setup.
+
+poetry install --only main


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Adds install scripts and updates the `.serviceconfig` files for all the examples.

### Why should this Pull Request be merged?

Pulling a plug-in from a Plug-in Library will cause DiscoveryService to "install" the plug-in - if an install script is specified.  In order to get `poetry` to install the python dependencies for these examples, we're adding install scripts for them all.

### What testing has been done?
Verified the examples work as expected.