### PR TITLE
[releases/2.0] Cherry-pick: Fix ReadTheDocs build by including working directory for post-install…

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,10 +7,8 @@ build:
   jobs:
     post_create_environment:
       - pip install poetry==1.8.2
-      # Tell poetry to not use a virtual environment
-      - poetry config virtualenvs.create false
     post_install:
-      - poetry install --with docs
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry -C packages/service/ install --with docs
 
 sphinx:
   configuration: packages/service/_docs_source/conf.py


### PR DESCRIPTION
* Fix working directory for post-install

* Update to pushd packages/service/ && poetry install --with docs

* Update to poetry -C packages/service/ install --with docs

* Use RTD virtual environment

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).
