### PR TITLE
Change the generator tool name to ni-measurement-plugin-generator

### DIFF
--- a/packages/generator/pyproject.toml
+++ b/packages/generator/pyproject.toml
@@ -30,7 +30,7 @@ ni-python-styleguide = ">=0.4.1"
 mypy = ">=1.0"
 
 [tool.poetry.scripts]
-ni-measurement-plugin-sdk-generator = "ni_measurement_plugin_sdk_generator.template:create_measurement"
+ni-measurement-plugin-generator = "ni_measurement_plugin_sdk_generator.template:create_measurement"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Changes the name of the plugin generator command to `ni-measurement-plugin-generator`.
![image](https://github.com/user-attachments/assets/a64e3247-26f0-4dfb-80ca-4aaea1c55b6a)


### Why should this Pull Request be merged?

We want to change the way users invoke the generator so they don't get confused. `ni-measurement-plugin-sdk-generator` could indicate you're 'generating a plugin SDK'.

### What testing has been done?

Ran the tool locally.