### PR TITLE
[releases/2.0] Cherry-pick: Change the generator tool name to ni-measurement-plugin-generator

### DIFF
--- a/packages/generator/pyproject.toml
+++ b/packages/generator/pyproject.toml
@@ -30,7 +30,7 @@ ni-python-styleguide = ">=0.4.1"
 mypy = ">=1.0"
 
 [tool.poetry.scripts]
-ni-measurement-plugin-sdk-generator = "ni_measurement_plugin_sdk_generator.template:create_measurement"
+ni-measurement-plugin-generator = "ni_measurement_plugin_sdk_generator.template:create_measurement"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Cherry-pick the change to the measurement plugin generator tool.