### PR TITLE
Update the stubs for the ni-apis proto files that are out of date

### DIFF
--- a/packages/service/ni_measurement_plugin_sdk_service/_internal/stubs/ni/measurementlink/discovery/v1/discovery_service_pb2.py
+++ b/packages/service/ni_measurement_plugin_sdk_service/_internal/stubs/ni/measurementlink/discovery/v1/discovery_service_pb2.py
@@ -13,7 +13,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n7ni/measurementlink/discovery/v1/discovery_service.proto\x12\x1fni.measurementlink.discovery.v1\"\x84\x02\n\x11ServiceDescriptor\x12\x14\n\x0c\x64isplay_name\x18\x01 \x01(\t\x12\x17\n\x0f\x64\x65scription_url\x18\x02 \x01(\t\x12\x1b\n\x13provided_interfaces\x18\x03 \x03(\t\x12\x15\n\rservice_class\x18\x04 \x01(\t\x12X\n\x0b\x61nnotations\x18\x05 \x03(\x0b\x32\x43.ni.measurementlink.discovery.v1.ServiceDescriptor.AnnotationsEntry\x1a\x32\n\x10\x41nnotationsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"Z\n\x0fServiceLocation\x12\x10\n\x08location\x18\x01 \x01(\t\x12\x15\n\rinsecure_port\x18\x02 \x01(\t\x12\x1e\n\x16ssl_authenticated_port\x18\x03 \x01(\t\"\xad\x01\n\x16RegisterServiceRequest\x12O\n\x13service_description\x18\x01 \x01(\x0b\x32\x32.ni.measurementlink.discovery.v1.ServiceDescriptor\x12\x42\n\x08location\x18\x02 \x01(\x0b\x32\x30.ni.measurementlink.discovery.v1.ServiceLocation\"2\n\x17RegisterServiceResponse\x12\x17\n\x0fregistration_id\x18\x01 \x01(\t\"3\n\x18UnregisterServiceRequest\x12\x17\n\x0fregistration_id\x18\x01 \x01(\t\"\x1b\n\x19UnregisterServiceResponse\"6\n\x18\x45numerateServicesRequest\x12\x1a\n\x12provided_interface\x18\x01 \x01(\t\"\x80\x01\n\x19\x45numerateServicesResponse\x12N\n\x12\x61vailable_services\x18\x01 \x03(\x0b\x32\x32.ni.measurementlink.discovery.v1.ServiceDescriptor\x12\x13\n\x0bunreachable\x18\x02 \x03(\t\"e\n\x15ResolveServiceRequest\x12\x1a\n\x12provided_interface\x18\x01 \x01(\t\x12\x15\n\rservice_class\x18\x02 \x01(\t\x12\x19\n\x11\x64\x65ployment_target\x18\x03 \x01(\t\"6\n\x15\x43omputeNodeDescriptor\x12\x0b\n\x03url\x18\x01 \x01(\t\x12\x10\n\x08is_local\x18\x02 \x01(\x08\"\x1e\n\x1c\x45numerateComputeNodesRequest\"n\n\x1d\x45numerateComputeNodesResponse\x12M\n\rcompute_nodes\x18\x01 \x03(\x0b\x32\x36.ni.measurementlink.discovery.v1.ComputeNodeDescriptor2\xc8\x05\n\x10\x44iscoveryService\x12\x84\x01\n\x0fRegisterService\x12\x37.ni.measurementlink.discovery.v1.RegisterServiceRequest\x1a\x38.ni.measurementlink.discovery.v1.RegisterServiceResponse\x12\x8a\x01\n\x11UnregisterService\x12\x39.ni.measurementlink.discovery.v1.UnregisterServiceRequest\x1a:.ni.measurementlink.discovery.v1.UnregisterServiceResponse\x12\x8a\x01\n\x11\x45numerateServices\x12\x39.ni.measurementlink.discovery.v1.EnumerateServicesRequest\x1a:.ni.measurementlink.discovery.v1.EnumerateServicesResponse\x12z\n\x0eResolveService\x12\x36.ni.measurementlink.discovery.v1.ResolveServiceRequest\x1a\x30.ni.measurementlink.discovery.v1.ServiceLocation\x12\x96\x01\n\x15\x45numerateComputeNodes\x12=.ni.measurementlink.discovery.v1.EnumerateComputeNodesRequest\x1a>.ni.measurementlink.discovery.v1.EnumerateComputeNodesResponseB\xcc\x01\n#com.ni.measurementlink.discovery.v1B\x15\x44iscoveryServiceProtoP\x01Z\x0b\x64iscoveryv1\xa2\x02\x04NIMD\xaa\x02\x30NationalInstruments.MeasurementLink.Discovery.V1\xca\x02\x1fNI\\MeasurementLink\\Discovery\\V1\xea\x02\"NI::MeasurementLink::Discovery::V1b\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n7ni/measurementlink/discovery/v1/discovery_service.proto\x12\x1fni.measurementlink.discovery.v1\"\x96\x02\n\x11ServiceDescriptor\x12\x14\n\x0c\x64isplay_name\x18\x01 \x01(\t\x12\x17\n\x0f\x64\x65scription_url\x18\x02 \x01(\t\x12\x1b\n\x13provided_interfaces\x18\x03 \x03(\t\x12\x15\n\rservice_class\x18\x04 \x01(\t\x12X\n\x0b\x61nnotations\x18\x05 \x03(\x0b\x32\x43.ni.measurementlink.discovery.v1.ServiceDescriptor.AnnotationsEntry\x12\x10\n\x08versions\x18\x06 \x03(\t\x1a\x32\n\x10\x41nnotationsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"Z\n\x0fServiceLocation\x12\x10\n\x08location\x18\x01 \x01(\t\x12\x15\n\rinsecure_port\x18\x02 \x01(\t\x12\x1e\n\x16ssl_authenticated_port\x18\x03 \x01(\t\"\xad\x01\n\x16RegisterServiceRequest\x12O\n\x13service_description\x18\x01 \x01(\x0b\x32\x32.ni.measurementlink.discovery.v1.ServiceDescriptor\x12\x42\n\x08location\x18\x02 \x01(\x0b\x32\x30.ni.measurementlink.discovery.v1.ServiceLocation\"2\n\x17RegisterServiceResponse\x12\x17\n\x0fregistration_id\x18\x01 \x01(\t\"3\n\x18UnregisterServiceRequest\x12\x17\n\x0fregistration_id\x18\x01 \x01(\t\"\x1b\n\x19UnregisterServiceResponse\"M\n\x18\x45numerateServicesRequest\x12\x1a\n\x12provided_interface\x18\x01 \x01(\t\x12\x15\n\rservice_class\x18\x02 \x01(\t\"\x80\x01\n\x19\x45numerateServicesResponse\x12N\n\x12\x61vailable_services\x18\x01 \x03(\x0b\x32\x32.ni.measurementlink.discovery.v1.ServiceDescriptor\x12\x13\n\x0bunreachable\x18\x02 \x03(\t\"v\n\x15ResolveServiceRequest\x12\x1a\n\x12provided_interface\x18\x01 \x01(\t\x12\x15\n\rservice_class\x18\x02 \x01(\t\x12\x19\n\x11\x64\x65ployment_target\x18\x03 \x01(\t\x12\x0f\n\x07version\x18\x04 \x01(\t\"\x85\x01\n$ResolveServiceWithInformationRequest\x12\x1a\n\x12provided_interface\x18\x01 \x01(\t\x12\x15\n\rservice_class\x18\x02 \x01(\t\x12\x19\n\x11\x64\x65ployment_target\x18\x03 \x01(\t\x12\x0f\n\x07version\x18\x04 \x01(\t\"\xc3\x01\n%ResolveServiceWithInformationResponse\x12J\n\x10service_location\x18\x01 \x01(\x0b\x32\x30.ni.measurementlink.discovery.v1.ServiceLocation\x12N\n\x12service_descriptor\x18\x02 \x01(\x0b\x32\x32.ni.measurementlink.discovery.v1.ServiceDescriptor\"6\n\x15\x43omputeNodeDescriptor\x12\x0b\n\x03url\x18\x01 \x01(\t\x12\x10\n\x08is_local\x18\x02 \x01(\x08\"\x1e\n\x1c\x45numerateComputeNodesRequest\"n\n\x1d\x45numerateComputeNodesResponse\x12M\n\rcompute_nodes\x18\x01 \x03(\x0b\x32\x36.ni.measurementlink.discovery.v1.ComputeNodeDescriptor2\xf9\x06\n\x10\x44iscoveryService\x12\x84\x01\n\x0fRegisterService\x12\x37.ni.measurementlink.discovery.v1.RegisterServiceRequest\x1a\x38.ni.measurementlink.discovery.v1.RegisterServiceResponse\x12\x8a\x01\n\x11UnregisterService\x12\x39.ni.measurementlink.discovery.v1.UnregisterServiceRequest\x1a:.ni.measurementlink.discovery.v1.UnregisterServiceResponse\x12\x8a\x01\n\x11\x45numerateServices\x12\x39.ni.measurementlink.discovery.v1.EnumerateServicesRequest\x1a:.ni.measurementlink.discovery.v1.EnumerateServicesResponse\x12z\n\x0eResolveService\x12\x36.ni.measurementlink.discovery.v1.ResolveServiceRequest\x1a\x30.ni.measurementlink.discovery.v1.ServiceLocation\x12\xae\x01\n\x1dResolveServiceWithInformation\x12\x45.ni.measurementlink.discovery.v1.ResolveServiceWithInformationRequest\x1a\x46.ni.measurementlink.discovery.v1.ResolveServiceWithInformationResponse\x12\x96\x01\n\x15\x45numerateComputeNodes\x12=.ni.measurementlink.discovery.v1.EnumerateComputeNodesRequest\x1a>.ni.measurementlink.discovery.v1.EnumerateComputeNodesResponseB\xcc\x01\n#com.ni.measurementlink.discovery.v1B\x15\x44iscoveryServiceProtoP\x01Z\x0b\x64iscoveryv1\xa2\x02\x04NIMD\xaa\x02\x30NationalInstruments.MeasurementLink.Discovery.V1\xca\x02\x1fNI\\MeasurementLink\\Discovery\\V1\xea\x02\"NI::MeasurementLink::Discovery::V1b\x06proto3')
 
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, globals())
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'ni.measurementlink.discovery.v1.discovery_service_pb2', globals())
@@ -24,31 +24,35 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _SERVICEDESCRIPTOR_ANNOTATIONSENTRY._options = None
   _SERVICEDESCRIPTOR_ANNOTATIONSENTRY._serialized_options = b'8\001'
   _SERVICEDESCRIPTOR._serialized_start=93
-  _SERVICEDESCRIPTOR._serialized_end=353
-  _SERVICEDESCRIPTOR_ANNOTATIONSENTRY._serialized_start=303
-  _SERVICEDESCRIPTOR_ANNOTATIONSENTRY._serialized_end=353
-  _SERVICELOCATION._serialized_start=355
-  _SERVICELOCATION._serialized_end=445
-  _REGISTERSERVICEREQUEST._serialized_start=448
-  _REGISTERSERVICEREQUEST._serialized_end=621
-  _REGISTERSERVICERESPONSE._serialized_start=623
-  _REGISTERSERVICERESPONSE._serialized_end=673
-  _UNREGISTERSERVICEREQUEST._serialized_start=675
-  _UNREGISTERSERVICEREQUEST._serialized_end=726
-  _UNREGISTERSERVICERESPONSE._serialized_start=728
-  _UNREGISTERSERVICERESPONSE._serialized_end=755
-  _ENUMERATESERVICESREQUEST._serialized_start=757
-  _ENUMERATESERVICESREQUEST._serialized_end=811
-  _ENUMERATESERVICESRESPONSE._serialized_start=814
-  _ENUMERATESERVICESRESPONSE._serialized_end=942
-  _RESOLVESERVICEREQUEST._serialized_start=944
-  _RESOLVESERVICEREQUEST._serialized_end=1045
-  _COMPUTENODEDESCRIPTOR._serialized_start=1047
-  _COMPUTENODEDESCRIPTOR._serialized_end=1101
-  _ENUMERATECOMPUTENODESREQUEST._serialized_start=1103
-  _ENUMERATECOMPUTENODESREQUEST._serialized_end=1133
-  _ENUMERATECOMPUTENODESRESPONSE._serialized_start=1135
-  _ENUMERATECOMPUTENODESRESPONSE._serialized_end=1245
-  _DISCOVERYSERVICE._serialized_start=1248
-  _DISCOVERYSERVICE._serialized_end=1960
+  _SERVICEDESCRIPTOR._serialized_end=371
+  _SERVICEDESCRIPTOR_ANNOTATIONSENTRY._serialized_start=321
+  _SERVICEDESCRIPTOR_ANNOTATIONSENTRY._serialized_end=371
+  _SERVICELOCATION._serialized_start=373
+  _SERVICELOCATION._serialized_end=463
+  _REGISTERSERVICEREQUEST._serialized_start=466
+  _REGISTERSERVICEREQUEST._serialized_end=639
+  _REGISTERSERVICERESPONSE._serialized_start=641
+  _REGISTERSERVICERESPONSE._serialized_end=691
+  _UNREGISTERSERVICEREQUEST._serialized_start=693
+  _UNREGISTERSERVICEREQUEST._serialized_end=744
+  _UNREGISTERSERVICERESPONSE._serialized_start=746
+  _UNREGISTERSERVICERESPONSE._serialized_end=773
+  _ENUMERATESERVICESREQUEST._serialized_start=775
+  _ENUMERATESERVICESREQUEST._serialized_end=852
+  _ENUMERATESERVICESRESPONSE._serialized_start=855
+  _ENUMERATESERVICESRESPONSE._serialized_end=983
+  _RESOLVESERVICEREQUEST._serialized_start=985
+  _RESOLVESERVICEREQUEST._serialized_end=1103
+  _RESOLVESERVICEWITHINFORMATIONREQUEST._serialized_start=1106
+  _RESOLVESERVICEWITHINFORMATIONREQUEST._serialized_end=1239
+  _RESOLVESERVICEWITHINFORMATIONRESPONSE._serialized_start=1242
+  _RESOLVESERVICEWITHINFORMATIONRESPONSE._serialized_end=1437
+  _COMPUTENODEDESCRIPTOR._serialized_start=1439
+  _COMPUTENODEDESCRIPTOR._serialized_end=1493
+  _ENUMERATECOMPUTENODESREQUEST._serialized_start=1495
+  _ENUMERATECOMPUTENODESREQUEST._serialized_end=1525
+  _ENUMERATECOMPUTENODESRESPONSE._serialized_start=1527
+  _ENUMERATECOMPUTENODESRESPONSE._serialized_end=1637
+  _DISCOVERYSERVICE._serialized_start=1640
+  _DISCOVERYSERVICE._serialized_end=2529
 # @@protoc_insertion_point(module_scope)

--- a/packages/service/ni_measurement_plugin_sdk_service/_internal/stubs/ni/measurementlink/discovery/v1/discovery_service_pb2.pyi
+++ b/packages/service/ni_measurement_plugin_sdk_service/_internal/stubs/ni/measurementlink/discovery/v1/discovery_service_pb2.pyi
@@ -43,6 +43,7 @@ class ServiceDescriptor(google.protobuf.message.Message):
     PROVIDED_INTERFACES_FIELD_NUMBER: builtins.int
     SERVICE_CLASS_FIELD_NUMBER: builtins.int
     ANNOTATIONS_FIELD_NUMBER: builtins.int
+    VERSIONS_FIELD_NUMBER: builtins.int
     display_name: builtins.str
     """Required. The user visible name of the service."""
     description_url: builtins.str
@@ -75,6 +76,23 @@ class ServiceDescriptor(google.protobuf.message.Message):
           - Example: "[\\"powerup\\", \\"current\\"]"
         """
 
+    @property
+    def versions(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[builtins.str]:
+        """This field is used differently based on the message in which it is used.
+
+        When used in a RegisterServiceRequest, this field must contain a single
+        version, and that version must follow the major.minor.patch format.
+        The version 0.0.1 is reserved for internal use, and cannot be specified.
+        If no version is specified, the version 0.0.1 will be used internally
+        for the registered service.
+
+        When returned from EnumerateServicesResponse, this field will contain the
+        list of versions that are available for the associated service.
+
+        When returned from ResolveServiceWithInformationResponse, this field will
+        contain the version of the resolved service.
+        """
+
     def __init__(
         self,
         *,
@@ -83,8 +101,9 @@ class ServiceDescriptor(google.protobuf.message.Message):
         provided_interfaces: collections.abc.Iterable[builtins.str] | None = ...,
         service_class: builtins.str = ...,
         annotations: collections.abc.Mapping[builtins.str, builtins.str] | None = ...,
+        versions: collections.abc.Iterable[builtins.str] | None = ...,
     ) -> None: ...
-    def ClearField(self, field_name: typing.Literal["annotations", b"annotations", "description_url", b"description_url", "display_name", b"display_name", "provided_interfaces", b"provided_interfaces", "service_class", b"service_class"]) -> None: ...
+    def ClearField(self, field_name: typing.Literal["annotations", b"annotations", "description_url", b"description_url", "display_name", b"display_name", "provided_interfaces", b"provided_interfaces", "service_class", b"service_class", "versions", b"versions"]) -> None: ...
 
 global___ServiceDescriptor = ServiceDescriptor
 
@@ -192,16 +211,25 @@ class EnumerateServicesRequest(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
     PROVIDED_INTERFACE_FIELD_NUMBER: builtins.int
+    SERVICE_CLASS_FIELD_NUMBER: builtins.int
     provided_interface: builtins.str
     """Optional. The gRPC full name of the service interface that is needed. If empty,
     information for all services registered with the discovery service will be returned.
+    """
+    service_class: builtins.str
+    """Optional. The "class" of the service that should be matched. Using this field can
+    be a useful way to determine the available versions of a specific service.  If used
+    in conjunction with the 'provided_interface' field, the 'service_class' field will
+    be used to filter the results to only those services that match the provided
+    interface and service class.
     """
     def __init__(
         self,
         *,
         provided_interface: builtins.str = ...,
+        service_class: builtins.str = ...,
     ) -> None: ...
-    def ClearField(self, field_name: typing.Literal["provided_interface", b"provided_interface"]) -> None: ...
+    def ClearField(self, field_name: typing.Literal["provided_interface", b"provided_interface", "service_class", b"service_class"]) -> None: ...
 
 global___EnumerateServicesRequest = EnumerateServicesRequest
 
@@ -240,6 +268,7 @@ class ResolveServiceRequest(google.protobuf.message.Message):
     PROVIDED_INTERFACE_FIELD_NUMBER: builtins.int
     SERVICE_CLASS_FIELD_NUMBER: builtins.int
     DEPLOYMENT_TARGET_FIELD_NUMBER: builtins.int
+    VERSION_FIELD_NUMBER: builtins.int
     provided_interface: builtins.str
     """Required. This corresponds to the gRPC Full Name of the service and should match the information
     that was supplied in the RegisterServiceRequest message.
@@ -255,16 +284,81 @@ class ResolveServiceRequest(google.protobuf.message.Message):
     local deployment target.  If the service cannot be resolved from the specified deployment
     target, an error is returned.
     """
+    version: builtins.str
+    """Optional. The version of the service to resolve. If not specified, the latest version will be resolved."""
     def __init__(
         self,
         *,
         provided_interface: builtins.str = ...,
         service_class: builtins.str = ...,
         deployment_target: builtins.str = ...,
+        version: builtins.str = ...,
     ) -> None: ...
-    def ClearField(self, field_name: typing.Literal["deployment_target", b"deployment_target", "provided_interface", b"provided_interface", "service_class", b"service_class"]) -> None: ...
+    def ClearField(self, field_name: typing.Literal["deployment_target", b"deployment_target", "provided_interface", b"provided_interface", "service_class", b"service_class", "version", b"version"]) -> None: ...
 
 global___ResolveServiceRequest = ResolveServiceRequest
+
+@typing.final
+class ResolveServiceWithInformationRequest(google.protobuf.message.Message):
+    DESCRIPTOR: google.protobuf.descriptor.Descriptor
+
+    PROVIDED_INTERFACE_FIELD_NUMBER: builtins.int
+    SERVICE_CLASS_FIELD_NUMBER: builtins.int
+    DEPLOYMENT_TARGET_FIELD_NUMBER: builtins.int
+    VERSION_FIELD_NUMBER: builtins.int
+    provided_interface: builtins.str
+    """Required. This corresponds to the gRPC Full Name of the service and should match the information
+    that was supplied in the RegisterServiceRequest message.
+    """
+    service_class: builtins.str
+    """Optional. The service "class" that should be matched. If the value of this field is not specified and there
+    is more than one matching service registered, an error is returned.
+    """
+    deployment_target: builtins.str
+    """Optional. Indicates the deployment target from which the service should be resolved.
+    The value of this field can be obtained from the results of the EnumerateComputeNodes method.
+    If the value of this field is not specified, the service will be resolved from the
+    local deployment target.  If the service cannot be resolved from the specified deployment
+    target, an error is returned.
+    """
+    version: builtins.str
+    """Optional. The version of the service to resolve. If not specified, the latest version will be resolved."""
+    def __init__(
+        self,
+        *,
+        provided_interface: builtins.str = ...,
+        service_class: builtins.str = ...,
+        deployment_target: builtins.str = ...,
+        version: builtins.str = ...,
+    ) -> None: ...
+    def ClearField(self, field_name: typing.Literal["deployment_target", b"deployment_target", "provided_interface", b"provided_interface", "service_class", b"service_class", "version", b"version"]) -> None: ...
+
+global___ResolveServiceWithInformationRequest = ResolveServiceWithInformationRequest
+
+@typing.final
+class ResolveServiceWithInformationResponse(google.protobuf.message.Message):
+    DESCRIPTOR: google.protobuf.descriptor.Descriptor
+
+    SERVICE_LOCATION_FIELD_NUMBER: builtins.int
+    SERVICE_DESCRIPTOR_FIELD_NUMBER: builtins.int
+    @property
+    def service_location(self) -> global___ServiceLocation:
+        """The canonical location information of the service."""
+
+    @property
+    def service_descriptor(self) -> global___ServiceDescriptor:
+        """The description of the service."""
+
+    def __init__(
+        self,
+        *,
+        service_location: global___ServiceLocation | None = ...,
+        service_descriptor: global___ServiceDescriptor | None = ...,
+    ) -> None: ...
+    def HasField(self, field_name: typing.Literal["service_descriptor", b"service_descriptor", "service_location", b"service_location"]) -> builtins.bool: ...
+    def ClearField(self, field_name: typing.Literal["service_descriptor", b"service_descriptor", "service_location", b"service_location"]) -> None: ...
+
+global___ResolveServiceWithInformationResponse = ResolveServiceWithInformationResponse
 
 @typing.final
 class ComputeNodeDescriptor(google.protobuf.message.Message):

--- a/packages/service/ni_measurement_plugin_sdk_service/_internal/stubs/ni/measurementlink/discovery/v1/discovery_service_pb2_grpc.py
+++ b/packages/service/ni_measurement_plugin_sdk_service/_internal/stubs/ni/measurementlink/discovery/v1/discovery_service_pb2_grpc.py
@@ -36,6 +36,11 @@ class DiscoveryServiceStub(object):
                 request_serializer=ni_dot_measurementlink_dot_discovery_dot_v1_dot_discovery__service__pb2.ResolveServiceRequest.SerializeToString,
                 response_deserializer=ni_dot_measurementlink_dot_discovery_dot_v1_dot_discovery__service__pb2.ServiceLocation.FromString,
                 )
+        self.ResolveServiceWithInformation = channel.unary_unary(
+                '/ni.measurementlink.discovery.v1.DiscoveryService/ResolveServiceWithInformation',
+                request_serializer=ni_dot_measurementlink_dot_discovery_dot_v1_dot_discovery__service__pb2.ResolveServiceWithInformationRequest.SerializeToString,
+                response_deserializer=ni_dot_measurementlink_dot_discovery_dot_v1_dot_discovery__service__pb2.ResolveServiceWithInformationResponse.FromString,
+                )
         self.EnumerateComputeNodes = channel.unary_unary(
                 '/ni.measurementlink.discovery.v1.DiscoveryService/EnumerateComputeNodes',
                 request_serializer=ni_dot_measurementlink_dot_discovery_dot_v1_dot_discovery__service__pb2.EnumerateComputeNodesRequest.SerializeToString,
@@ -94,6 +99,15 @@ class DiscoveryServiceServicer(object):
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
+    def ResolveServiceWithInformation(self, request, context):
+        """Similar to ResolveService, returns information for the service in addition to the location of the service.
+        This is useful if you want to avoid the overhead of having to call EnumerateServices to get this information as part of
+        resolution of the service. See ResolveService for additional documentation related to resolving the service.
+        """
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
     def EnumerateComputeNodes(self, request, context):
         """Enumerate all compute nodes that have registered themselves in the current session.
         These compute nodes are targets available for execution of services.
@@ -126,6 +140,11 @@ def add_DiscoveryServiceServicer_to_server(servicer, server):
                     servicer.ResolveService,
                     request_deserializer=ni_dot_measurementlink_dot_discovery_dot_v1_dot_discovery__service__pb2.ResolveServiceRequest.FromString,
                     response_serializer=ni_dot_measurementlink_dot_discovery_dot_v1_dot_discovery__service__pb2.ServiceLocation.SerializeToString,
+            ),
+            'ResolveServiceWithInformation': grpc.unary_unary_rpc_method_handler(
+                    servicer.ResolveServiceWithInformation,
+                    request_deserializer=ni_dot_measurementlink_dot_discovery_dot_v1_dot_discovery__service__pb2.ResolveServiceWithInformationRequest.FromString,
+                    response_serializer=ni_dot_measurementlink_dot_discovery_dot_v1_dot_discovery__service__pb2.ResolveServiceWithInformationResponse.SerializeToString,
             ),
             'EnumerateComputeNodes': grpc.unary_unary_rpc_method_handler(
                     servicer.EnumerateComputeNodes,
@@ -209,6 +228,23 @@ class DiscoveryService(object):
         return grpc.experimental.unary_unary(request, target, '/ni.measurementlink.discovery.v1.DiscoveryService/ResolveService',
             ni_dot_measurementlink_dot_discovery_dot_v1_dot_discovery__service__pb2.ResolveServiceRequest.SerializeToString,
             ni_dot_measurementlink_dot_discovery_dot_v1_dot_discovery__service__pb2.ServiceLocation.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+
+    @staticmethod
+    def ResolveServiceWithInformation(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(request, target, '/ni.measurementlink.discovery.v1.DiscoveryService/ResolveServiceWithInformation',
+            ni_dot_measurementlink_dot_discovery_dot_v1_dot_discovery__service__pb2.ResolveServiceWithInformationRequest.SerializeToString,
+            ni_dot_measurementlink_dot_discovery_dot_v1_dot_discovery__service__pb2.ResolveServiceWithInformationResponse.FromString,
             options, channel_credentials,
             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 

--- a/packages/service/ni_measurement_plugin_sdk_service/_internal/stubs/ni/measurementlink/discovery/v1/discovery_service_pb2_grpc.pyi
+++ b/packages/service/ni_measurement_plugin_sdk_service/_internal/stubs/ni/measurementlink/discovery/v1/discovery_service_pb2_grpc.pyi
@@ -70,6 +70,15 @@ class DiscoveryServiceStub:
     - FAILED_PRECONDITION: More than one service matching the resolve request was found
     """
 
+    ResolveServiceWithInformation: grpc.UnaryUnaryMultiCallable[
+        ni_measurementlink_discovery_v1_discovery_service_pb2.ResolveServiceWithInformationRequest,
+        ni_measurementlink_discovery_v1_discovery_service_pb2.ResolveServiceWithInformationResponse,
+    ]
+    """Similar to ResolveService, returns information for the service in addition to the location of the service.
+    This is useful if you want to avoid the overhead of having to call EnumerateServices to get this information as part of
+    resolution of the service. See ResolveService for additional documentation related to resolving the service.
+    """
+
     EnumerateComputeNodes: grpc.UnaryUnaryMultiCallable[
         ni_measurementlink_discovery_v1_discovery_service_pb2.EnumerateComputeNodesRequest,
         ni_measurementlink_discovery_v1_discovery_service_pb2.EnumerateComputeNodesResponse,
@@ -128,6 +137,15 @@ class DiscoveryServiceAsyncStub:
     - INVALID_ARGUMENT: provided_interfaces is empty
     - NOT_FOUND: No service matching the resolve request was found
     - FAILED_PRECONDITION: More than one service matching the resolve request was found
+    """
+
+    ResolveServiceWithInformation: grpc.aio.UnaryUnaryMultiCallable[
+        ni_measurementlink_discovery_v1_discovery_service_pb2.ResolveServiceWithInformationRequest,
+        ni_measurementlink_discovery_v1_discovery_service_pb2.ResolveServiceWithInformationResponse,
+    ]
+    """Similar to ResolveService, returns information for the service in addition to the location of the service.
+    This is useful if you want to avoid the overhead of having to call EnumerateServices to get this information as part of
+    resolution of the service. See ResolveService for additional documentation related to resolving the service.
     """
 
     EnumerateComputeNodes: grpc.aio.UnaryUnaryMultiCallable[
@@ -196,6 +214,17 @@ class DiscoveryServiceServicer(metaclass=abc.ABCMeta):
         - INVALID_ARGUMENT: provided_interfaces is empty
         - NOT_FOUND: No service matching the resolve request was found
         - FAILED_PRECONDITION: More than one service matching the resolve request was found
+        """
+
+    @abc.abstractmethod
+    def ResolveServiceWithInformation(
+        self,
+        request: ni_measurementlink_discovery_v1_discovery_service_pb2.ResolveServiceWithInformationRequest,
+        context: _ServicerContext,
+    ) -> typing.Union[ni_measurementlink_discovery_v1_discovery_service_pb2.ResolveServiceWithInformationResponse, collections.abc.Awaitable[ni_measurementlink_discovery_v1_discovery_service_pb2.ResolveServiceWithInformationResponse]]:
+        """Similar to ResolveService, returns information for the service in addition to the location of the service.
+        This is useful if you want to avoid the overhead of having to call EnumerateServices to get this information as part of
+        resolution of the service. See ResolveService for additional documentation related to resolving the service.
         """
 
     @abc.abstractmethod

--- a/packages/service/ni_measurement_plugin_sdk_service/_internal/stubs/ni/measurementlink/sessionmanagement/v1/session_management_service_pb2.pyi
+++ b/packages/service/ni_measurement_plugin_sdk_service/_internal/stubs/ni/measurementlink/sessionmanagement/v1/session_management_service_pb2.pyi
@@ -35,7 +35,7 @@ class SessionInformation(google.protobuf.message.Message):
     """
     instrument_type_id: builtins.str
     """Instrument type ID to identify which type of instrument the session represents.
-    Pin maps have built in instrument definitions using the following NI driver based instrument type ids:
+    The session management service has built in instrument definitions using the following NI driver based instrument type ids:
          "niDCPower"
          "niDigitalPattern"
          "niScope"
@@ -43,7 +43,7 @@ class SessionInformation(google.protobuf.message.Message):
          "niDAQmx"
          "niFGen"
          "niRelayDriver"
-    For custom instruments the user defined instrument type id is defined in the pin map file.
+    For custom instruments the user defined instrument type id is defined in the pin map file or custom session management plugin service.
     This field is readonly.
     """
     session_exists: builtins.bool
@@ -58,8 +58,8 @@ class SessionInformation(google.protobuf.message.Message):
 
     @property
     def channel_mappings(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___ChannelMapping]:
-        """List of site and pin/relay mappings with optional multiplexer information for each channel in the channel_list.
-        Each item represents a channel-to-pin connection for this instrument resource. In the case of shared pins, there is a separate item for each connection.
+        """List of site and I/O resource mappings with optional multiplexer information for each channel in the channel_list.
+        Each item represents a channel-to-I/O-resource connection for this instrument resource. In the case of shared pins, there is a separate item for each connection.
         This field is empty for any SessionInformation returned from ReserveAllRegisteredSessions.
         This field is readonly.
         """
@@ -89,13 +89,13 @@ class ChannelMapping(google.protobuf.message.Message):
     MULTIPLEXER_RESOURCE_NAME_FIELD_NUMBER: builtins.int
     MULTIPLEXER_ROUTE_FIELD_NUMBER: builtins.int
     pin_or_relay_name: builtins.str
-    """The pin or relay that is mapped to a channel."""
+    """The I/O resource that is mapped to a channel."""
     site: builtins.int
-    """The site on which the pin or relay is mapped to a channel.
+    """The site on which the I/O resource is mapped to a channel.
     For system pins/relays the site number is -1 since they do not belong to a specific site.
     """
     channel: builtins.str
-    """The channel to which the pin or relay is mapped on this site."""
+    """The channel to which the I/O resource is mapped on this site."""
     multiplexer_resource_name: builtins.str
     """The multiplexer resource name is used to open the multiplexer session in the driver."""
     multiplexer_route: builtins.str
@@ -162,7 +162,7 @@ class ReserveSessionsRequest(google.protobuf.message.Message):
     TIMEOUT_IN_MILLISECONDS_FIELD_NUMBER: builtins.int
     instrument_type_id: builtins.str
     """Optional. Instrument type ID for the measurement. If unspecified, reserve sessions for all instrument types connected in the registered pin map resource.
-    Pin maps have built in instrument definitions using the following NI driver based instrument type ids:
+    The session management service has built in instrument definitions using the following NI driver based instrument type ids:
          "niDCPower"
          "niDigitalPattern"
          "niScope"
@@ -170,7 +170,7 @@ class ReserveSessionsRequest(google.protobuf.message.Message):
          "niDAQmx"
          "niFGen"
          "niRelayDriver"
-    For custom instruments the user defined instrument type id is defined in the pin map file.
+    For custom instruments the user defined instrument type id is defined in the pin map file or custom session management plugin service.
     """
     timeout_in_milliseconds: builtins.int
     """Optional. Timeout for the reservation request.
@@ -178,11 +178,11 @@ class ReserveSessionsRequest(google.protobuf.message.Message):
     """
     @property
     def pin_map_context(self) -> ni_measurementlink_pin_map_context_pb2.PinMapContext:
-        """Required. Includes the pin map ID for the pin map in the Pin Map Service, as well as the list of sites for the measurement."""
+        """Optional. Includes the pin map ID for the pin map in the Pin Map Service, as well as the list of sites for the measurement. If unspecified, specify non-pin I/O resources for pin_or_relay_names."""
 
     @property
     def pin_or_relay_names(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[builtins.str]:
-        """Optional. List of pins, pin groups, relays, or relay groups to use for the measurement. If unspecified, reserve sessions for all pins and relays in the registered pin map resource."""
+        """Optional. List of I/O resources (pins, pin groups, relays, relay groups, or channels) to use for the measurement. If unspecified, reserve sessions for all pins and relays in the registered pin map resource."""
 
     def __init__(
         self,
@@ -224,11 +224,11 @@ class ReserveSessionsResponse(google.protobuf.message.Message):
     GROUP_MAPPINGS_FIELD_NUMBER: builtins.int
     @property
     def sessions(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___SessionInformation]:
-        """List of information needed to create or use each session for the given pin, site, and instrument type ID."""
+        """List of information needed to create or use each session for the given I/O resource, site, and instrument type ID."""
 
     @property
     def multiplexer_sessions(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___MultiplexerSessionInformation]:
-        """List of information needed to create or use each multiplexer session for the given pin, site, and instrument type ID."""
+        """List of information needed to create or use each multiplexer session for the given I/O resource, site, and instrument type ID."""
 
     @property
     def group_mappings(self) -> google.protobuf.internal.containers.MessageMap[builtins.str, global___ResolvedPinsOrRelays]:
@@ -341,7 +341,7 @@ class ReserveAllRegisteredSessionsRequest(google.protobuf.message.Message):
     """
     instrument_type_id: builtins.str
     """Optional. Instrument type ID of the registered sessions to reserve. If unspecified, reserve sessions for all instrument types connected in the registered pin map resource.
-    Pin maps have built in instrument definitions using the following NI driver based instrument type ids:
+    The session management service has built in instrument definitions using the following NI driver based instrument type ids:
          "niDCPower"
          "niDigitalPattern"
          "niScope"
@@ -349,7 +349,7 @@ class ReserveAllRegisteredSessionsRequest(google.protobuf.message.Message):
          "niDAQmx"
          "niFGen"
          "niRelayDriver"
-    For custom instruments the user defined instrument type id is defined in the pin map file.
+    For custom instruments the user defined instrument type id is defined in the pin map file or custom session management plugin service.
     """
     def __init__(
         self,

--- a/packages/service/ni_measurement_plugin_sdk_service/_internal/stubs/ni/measurementlink/sessionmanagement/v1/session_management_service_pb2_grpc.py
+++ b/packages/service/ni_measurement_plugin_sdk_service/_internal/stubs/ni/measurementlink/sessionmanagement/v1/session_management_service_pb2_grpc.py
@@ -6,7 +6,7 @@ from ni_measurement_plugin_sdk_service._internal.stubs.ni.measurementlink.sessio
 
 
 class SessionManagementServiceStub(object):
-    """Service to keep track of open sessions used by measurement services, and to allow measurement services to access sessions by pin and site.
+    """Service to keep track of open sessions used by measurement services, and to allow measurement services to access sessions by I/O resource and site.
     """
 
     def __init__(self, channel):
@@ -63,11 +63,11 @@ class SessionManagementServiceStub(object):
 
 
 class SessionManagementServiceServicer(object):
-    """Service to keep track of open sessions used by measurement services, and to allow measurement services to access sessions by pin and site.
+    """Service to keep track of open sessions used by measurement services, and to allow measurement services to access sessions by I/O resource and site.
     """
 
     def ReserveSessions(self, request, context):
-        """Reserve session(s) for the given pins or relays, sites, and instrument type ID and returns the information needed to create or access the session.
+        """Reserve session(s) for the given I/O resources (pins, relays, channels), sites, and instrument type ID and returns the information needed to create or access the session.
         Also reserves the session so other processes cannot access it with a ReserveSessions() call.
         Status Codes for errors:
         - INVALID_ARGUMENT:
@@ -216,7 +216,7 @@ def add_SessionManagementServiceServicer_to_server(servicer, server):
 
  # This class is part of an EXPERIMENTAL API.
 class SessionManagementService(object):
-    """Service to keep track of open sessions used by measurement services, and to allow measurement services to access sessions by pin and site.
+    """Service to keep track of open sessions used by measurement services, and to allow measurement services to access sessions by I/O resource and site.
     """
 
     @staticmethod

--- a/packages/service/ni_measurement_plugin_sdk_service/_internal/stubs/ni/measurementlink/sessionmanagement/v1/session_management_service_pb2_grpc.pyi
+++ b/packages/service/ni_measurement_plugin_sdk_service/_internal/stubs/ni/measurementlink/sessionmanagement/v1/session_management_service_pb2_grpc.pyi
@@ -18,14 +18,14 @@ class _ServicerContext(grpc.ServicerContext, grpc.aio.ServicerContext):  # type:
     ...
 
 class SessionManagementServiceStub:
-    """Service to keep track of open sessions used by measurement services, and to allow measurement services to access sessions by pin and site."""
+    """Service to keep track of open sessions used by measurement services, and to allow measurement services to access sessions by I/O resource and site."""
 
     def __init__(self, channel: typing.Union[grpc.Channel, grpc.aio.Channel]) -> None: ...
     ReserveSessions: grpc.UnaryUnaryMultiCallable[
         ni_measurementlink_sessionmanagement_v1_session_management_service_pb2.ReserveSessionsRequest,
         ni_measurementlink_sessionmanagement_v1_session_management_service_pb2.ReserveSessionsResponse,
     ]
-    """Reserve session(s) for the given pins or relays, sites, and instrument type ID and returns the information needed to create or access the session.
+    """Reserve session(s) for the given I/O resources (pins, relays, channels), sites, and instrument type ID and returns the information needed to create or access the session.
     Also reserves the session so other processes cannot access it with a ReserveSessions() call.
     Status Codes for errors:
     - INVALID_ARGUMENT:
@@ -113,13 +113,13 @@ class SessionManagementServiceStub:
     """Gets all multiplexer sessions currently registered with this service."""
 
 class SessionManagementServiceAsyncStub:
-    """Service to keep track of open sessions used by measurement services, and to allow measurement services to access sessions by pin and site."""
+    """Service to keep track of open sessions used by measurement services, and to allow measurement services to access sessions by I/O resource and site."""
 
     ReserveSessions: grpc.aio.UnaryUnaryMultiCallable[
         ni_measurementlink_sessionmanagement_v1_session_management_service_pb2.ReserveSessionsRequest,
         ni_measurementlink_sessionmanagement_v1_session_management_service_pb2.ReserveSessionsResponse,
     ]
-    """Reserve session(s) for the given pins or relays, sites, and instrument type ID and returns the information needed to create or access the session.
+    """Reserve session(s) for the given I/O resources (pins, relays, channels), sites, and instrument type ID and returns the information needed to create or access the session.
     Also reserves the session so other processes cannot access it with a ReserveSessions() call.
     Status Codes for errors:
     - INVALID_ARGUMENT:
@@ -207,7 +207,7 @@ class SessionManagementServiceAsyncStub:
     """Gets all multiplexer sessions currently registered with this service."""
 
 class SessionManagementServiceServicer(metaclass=abc.ABCMeta):
-    """Service to keep track of open sessions used by measurement services, and to allow measurement services to access sessions by pin and site."""
+    """Service to keep track of open sessions used by measurement services, and to allow measurement services to access sessions by I/O resource and site."""
 
     @abc.abstractmethod
     def ReserveSessions(
@@ -215,7 +215,7 @@ class SessionManagementServiceServicer(metaclass=abc.ABCMeta):
         request: ni_measurementlink_sessionmanagement_v1_session_management_service_pb2.ReserveSessionsRequest,
         context: _ServicerContext,
     ) -> typing.Union[ni_measurementlink_sessionmanagement_v1_session_management_service_pb2.ReserveSessionsResponse, collections.abc.Awaitable[ni_measurementlink_sessionmanagement_v1_session_management_service_pb2.ReserveSessionsResponse]]:
-        """Reserve session(s) for the given pins or relays, sites, and instrument type ID and returns the information needed to create or access the session.
+        """Reserve session(s) for the given I/O resources (pins, relays, channels), sites, and instrument type ID and returns the information needed to create or access the session.
         Also reserves the session so other processes cannot access it with a ReserveSessions() call.
         Status Codes for errors:
         - INVALID_ARGUMENT:


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

This PR updates the generated stubs for the discovery service and session management proto services.  It also updates the ni-apis submodule to refer to the latest commit.

Updated the stubs via `poetry run python .\scripts\generate_grpc_stubs.py`

### Why should this Pull Request be merged?

In preparation for plugin versioning support, we need the latest discovery service APIs.

### What testing has been done?

Automated testing.