### PR TITLE
service/tests: Fix psutil deprecation warning

### DIFF
--- a/packages/service/poetry.lock
+++ b/packages/service/poetry.lock
@@ -2212,4 +2212,4 @@ niswitch = ["niswitch"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "af41fe571d61df6869ab720a0a6fa5a286289d5700d648832445f58cb726befc"
+content-hash = "cd55c1b7c385a322ecc4eb0a2338d380dc7bb15d3fd9aeeab5a717b3edf9e547"

--- a/packages/service/pyproject.toml
+++ b/packages/service/pyproject.toml
@@ -73,8 +73,8 @@ types-protobuf = "^4.21"
 types-pkg-resources = "*"
 types-pywin32 = ">=304"
 grpc-stubs = "^1.53"
-psutil = ">=5.9"
-types-psutil = ">=5.9"
+psutil = ">=6.0"
+types-psutil = ">=6.0"
 # NumPy dropped support for Python 3.8 before adding support for Python 3.12, so
 # we need to include multiple NumPy versions in poetry.lock.
 numpy = [

--- a/packages/service/tests/acceptance/test_security.py
+++ b/packages/service/tests/acceptance/test_security.py
@@ -16,7 +16,7 @@ def test___loopback_measurement___listening_on_loopback_interface(
 
     listener_ips = [
         ip_address(conn.laddr.ip)
-        for conn in psutil.Process().connections()
+        for conn in psutil.Process().net_connections()
         if conn.laddr.port == insecure_port and conn.status == psutil.CONN_LISTEN
     ]
     assert len(listener_ips) >= 1 and all([ip.is_loopback for ip in listener_ips])


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Update test_security.py to call Process.net_connections() instead of Process.connections().

Update min version of psutil.

### Why should this Pull Request be merged?

Fix this deprecation warning:
```
tests/acceptance/test_security.py::test___loopback_measurement___listening_on_loopback_interface
  D:\dev\measurement-plugin-python\packages\service\tests\acceptance\test_security.py:19: DeprecationWarning: connections() is deprecated and will be removed; use net_connections() instead
    for conn in psutil.Process().connections()
```

### What testing has been done?

Ran updated test.