### PR TITLE
Add enumerate services API

### DIFF
--- a/packages/service/ni_measurement_plugin_sdk_service/discovery/_client.py
+++ b/packages/service/ni_measurement_plugin_sdk_service/discovery/_client.py
@@ -256,7 +256,7 @@ class DiscoveryClient:
                 provided_interfaces=list(service.provided_interfaces),
                 annotations=dict(service.annotations),
                 display_name=service.display_name,
-                versions=service.versions,
+                versions=list(service.versions),
             )
             for service in response.available_services
         ]

--- a/packages/service/ni_measurement_plugin_sdk_service/discovery/_client.py
+++ b/packages/service/ni_measurement_plugin_sdk_service/discovery/_client.py
@@ -2,7 +2,7 @@
 
 import logging
 import threading
-from typing import Optional
+from typing import Optional, Sequence
 
 import grpc
 from deprecation import deprecated
@@ -233,3 +233,29 @@ class DiscoveryClient:
             insecure_port=response.insecure_port,
             ssl_authenticated_port=response.ssl_authenticated_port,
         )
+
+    def enumerate_services(self, provided_interface: str) -> Sequence[ServiceInfo]:
+        """Enumerates all the services for the provided interface.
+
+        Args:
+            provided_interface: Interface to filter the services.
+
+        Returns:
+            The service details matching the provided interface.
+        """
+        request = discovery_service_pb2.EnumerateServicesRequest(
+            provided_interface=provided_interface
+        )
+
+        response = self._get_stub().EnumerateServices(request)
+
+        return [
+            ServiceInfo(
+                service.service_class,
+                service.description_url,
+                service.provided_interfaces,
+                service.annotations,
+                service.display_name,
+            )
+            for service in response.available_services
+        ]

--- a/packages/service/ni_measurement_plugin_sdk_service/discovery/_client.py
+++ b/packages/service/ni_measurement_plugin_sdk_service/discovery/_client.py
@@ -253,8 +253,8 @@ class DiscoveryClient:
             ServiceInfo(
                 service.service_class,
                 service.description_url,
-                service.provided_interfaces,
-                service.annotations,
+                list(service.provided_interfaces),
+                dict(service.annotations),
                 service.display_name,
             )
             for service in response.available_services

--- a/packages/service/ni_measurement_plugin_sdk_service/discovery/_client.py
+++ b/packages/service/ni_measurement_plugin_sdk_service/discovery/_client.py
@@ -238,10 +238,10 @@ class DiscoveryClient:
         """Enumerates all the services for the provided interface.
 
         Args:
-            provided_interface: Interface to filter the services.
+            provided_interface: The gRPC full name of the service.
 
         Returns:
-            The service details matching the provided interface.
+            The list of information describing the service.
         """
         request = discovery_service_pb2.EnumerateServicesRequest(
             provided_interface=provided_interface

--- a/packages/service/ni_measurement_plugin_sdk_service/discovery/_client.py
+++ b/packages/service/ni_measurement_plugin_sdk_service/discovery/_client.py
@@ -238,10 +238,10 @@ class DiscoveryClient:
         """Enumerates all the services for the provided interface.
 
         Args:
-            provided_interface: The gRPC full name of the service.
+            provided_interface: The gRPC full name of the services.
 
         Returns:
-            The list of information describing the service.
+            The list of information describing the services.
         """
         request = discovery_service_pb2.EnumerateServicesRequest(
             provided_interface=provided_interface
@@ -251,11 +251,11 @@ class DiscoveryClient:
 
         return [
             ServiceInfo(
-                service.service_class,
-                service.description_url,
-                list(service.provided_interfaces),
-                dict(service.annotations),
-                service.display_name,
+                service_class=service.service_class,
+                description_url=service.description_url,
+                provided_interfaces=list(service.provided_interfaces),
+                annotations=dict(service.annotations),
+                display_name=service.display_name,
             )
             for service in response.available_services
         ]

--- a/packages/service/ni_measurement_plugin_sdk_service/discovery/_client.py
+++ b/packages/service/ni_measurement_plugin_sdk_service/discovery/_client.py
@@ -256,6 +256,7 @@ class DiscoveryClient:
                 provided_interfaces=list(service.provided_interfaces),
                 annotations=dict(service.annotations),
                 display_name=service.display_name,
+                versions=service.versions,
             )
             for service in response.available_services
         ]

--- a/packages/service/tests/unit/test_discovery_client.py
+++ b/packages/service/tests/unit/test_discovery_client.py
@@ -341,7 +341,7 @@ def test___registered_measurements___enumerate_services___returns_list_of_measur
                 provided_interfaces=expected_service_info.provided_interfaces,
                 annotations=expected_service_info.annotations,
                 service_class=expected_service_info.service_class,
-                versions=expected_service_info.versions
+                versions=expected_service_info.versions,
             )
         ]
     )

--- a/packages/service/tests/unit/test_discovery_client.py
+++ b/packages/service/tests/unit/test_discovery_client.py
@@ -326,11 +326,11 @@ def test___registered_measurements___enumerate_services___returns_list_of_measur
     discovery_client: DiscoveryClient, discovery_service_stub: Mock
 ):
     grpc_service_descriptor = GrpcServiceDescriptor(
-        display_name = _TEST_SERVICE_INFO.display_name,
-        description_url = _TEST_SERVICE_INFO.description_url,
-        provided_interfaces = _TEST_SERVICE_INFO.provided_interfaces,
-        annotations = _TEST_SERVICE_INFO.annotations,
-        service_class = _TEST_SERVICE_INFO.service_class
+        display_name=_TEST_SERVICE_INFO.display_name,
+        description_url=_TEST_SERVICE_INFO.description_url,
+        provided_interfaces=_TEST_SERVICE_INFO.provided_interfaces,
+        annotations=_TEST_SERVICE_INFO.annotations,
+        service_class=_TEST_SERVICE_INFO.service_class,
     )
     grpc_service_descriptor.annotations[SERVICE_PROGRAMMINGLANGUAGE_KEY] = "Python"
     discovery_service_stub.EnumerateServices.return_value = EnumerateServicesResponse(

--- a/packages/service/tests/unit/test_discovery_client.py
+++ b/packages/service/tests/unit/test_discovery_client.py
@@ -1,6 +1,7 @@
 """Contains tests to validate the discovery_client.py.
 """
 
+import copy
 import json
 import pathlib
 import subprocess
@@ -89,6 +90,8 @@ _MOCK_REGISTRATION_FILE_CONTENT = {"discovery": {"path": "Discovery/NI.Discovery
 def test___service_not_registered___register_service___sends_request_and_returns_id(
     discovery_client: DiscoveryClient, discovery_service_stub: Mock
 ):
+    expected_service_info = copy.deepcopy(_TEST_SERVICE_INFO)
+    expected_service_info.annotations[SERVICE_PROGRAMMINGLANGUAGE_KEY] = "Python"
     discovery_service_stub.RegisterService.return_value = RegisterServiceResponse(
         registration_id="abcd"
     )
@@ -97,7 +100,7 @@ def test___service_not_registered___register_service___sends_request_and_returns
 
     discovery_service_stub.RegisterService.assert_called_once()
     request: RegisterServiceRequest = discovery_service_stub.RegisterService.call_args.args[0]
-    _assert_service_info_equal(_TEST_SERVICE_INFO, request.service_description)
+    _assert_service_info_equal(expected_service_info, request.service_description)
     _assert_service_location_equal(_TEST_SERVICE_LOCATION, request.location)
     assert registration_id == "abcd"
 
@@ -154,6 +157,8 @@ def test___service_not_registered___resolve_service___raises_not_found_error(
 def test___service_not_registered___register_measurement_service___sends_request_and_warns(
     discovery_client: DiscoveryClient, discovery_service_stub: Mock
 ):
+    expected_service_info = copy.deepcopy(_TEST_SERVICE_INFO)
+    expected_service_info.annotations[SERVICE_PROGRAMMINGLANGUAGE_KEY] = "Python"
     discovery_service_stub.RegisterService.return_value = RegisterServiceResponse(
         registration_id="abcd"
     )
@@ -165,7 +170,7 @@ def test___service_not_registered___register_measurement_service___sends_request
 
     discovery_service_stub.RegisterService.assert_called_once()
     request = discovery_service_stub.RegisterService.call_args.args[0]
-    _assert_service_info_equal(_TEST_SERVICE_INFO, request.service_description)
+    _assert_service_info_equal(expected_service_info, request.service_description)
     _assert_service_location_equal(_TEST_SERVICE_LOCATION_WITHOUT_SSL, request.location)
     assert discovery_client._registration_id == "abcd"
     assert registration_success_flag
@@ -321,9 +326,11 @@ def test___discovery_service_exe_unavailable___register_service___raises_file_no
     with pytest.raises(FileNotFoundError):
         discovery_client.register_service(_TEST_SERVICE_INFO, _TEST_SERVICE_LOCATION)
 
-
+@pytest.mark.parametrize(
+    "programming_language", ["Python", "LabVIEW"]
+) # 
 def test___registered_measurements___enumerate_services___returns_list_of_measurements(
-    discovery_client: DiscoveryClient, discovery_service_stub: Mock
+    discovery_client: DiscoveryClient, discovery_service_stub: Mock, programming_language: str
 ):
     grpc_service_descriptor = GrpcServiceDescriptor(
         display_name=_TEST_SERVICE_INFO.display_name,
@@ -332,7 +339,7 @@ def test___registered_measurements___enumerate_services___returns_list_of_measur
         annotations=_TEST_SERVICE_INFO.annotations,
         service_class=_TEST_SERVICE_INFO.service_class,
     )
-    grpc_service_descriptor.annotations[SERVICE_PROGRAMMINGLANGUAGE_KEY] = "Python"
+    grpc_service_descriptor.annotations[SERVICE_PROGRAMMINGLANGUAGE_KEY] = programming_language
     discovery_service_stub.EnumerateServices.return_value = EnumerateServicesResponse(
         available_services=[grpc_service_descriptor]
     )
@@ -345,7 +352,7 @@ def test___registered_measurements___enumerate_services___returns_list_of_measur
     request: EnumerateServicesRequest = discovery_service_stub.EnumerateServices.call_args.args[0]
     assert _TEST_SERVICE_INFO.provided_interfaces[1] == request.provided_interface
     for measurement in available_measurements:
-        _assert_service_info_equal(_TEST_SERVICE_INFO, measurement)
+        _assert_service_info_equal(grpc_service_descriptor, measurement)
 
 
 def test___no_registered_measurements___enumerate_services___returns_empty_list(
@@ -431,7 +438,6 @@ def _assert_service_location_equal(
 def _assert_service_info_equal(
     expected: ServiceInfo, actual: Union[ServiceInfo, GrpcServiceDescriptor]
 ) -> None:
-    expected.annotations[SERVICE_PROGRAMMINGLANGUAGE_KEY] = "Python"
     assert expected.display_name == actual.display_name
     assert expected.description_url == actual.description_url
     assert set(expected.provided_interfaces) == set(actual.provided_interfaces)

--- a/packages/service/tests/unit/test_discovery_client.py
+++ b/packages/service/tests/unit/test_discovery_client.py
@@ -325,15 +325,16 @@ def test___discovery_service_exe_unavailable___register_service___raises_file_no
 def test___registered_measurements___enumerate_services___returns_list_of_measurements(
     discovery_client: DiscoveryClient, discovery_service_stub: Mock
 ):
-    discovery_service_stub.RegisterService.return_value = RegisterServiceResponse(
-        registration_id="abcd"
+    grpc_service_descriptor = GrpcServiceDescriptor(
+        display_name = _TEST_SERVICE_INFO.display_name,
+        description_url = _TEST_SERVICE_INFO.description_url,
+        provided_interfaces = _TEST_SERVICE_INFO.provided_interfaces,
+        annotations = _TEST_SERVICE_INFO.annotations,
+        service_class = _TEST_SERVICE_INFO.service_class
     )
-    discovery_client.register_service(_TEST_SERVICE_INFO, _TEST_SERVICE_LOCATION)
-    register_service_request: RegisterServiceRequest = (
-        discovery_service_stub.RegisterService.call_args.args[0]
-    )
+    grpc_service_descriptor.annotations[SERVICE_PROGRAMMINGLANGUAGE_KEY] = "Python"
     discovery_service_stub.EnumerateServices.return_value = EnumerateServicesResponse(
-        available_services=[register_service_request.service_description]
+        available_services=[grpc_service_descriptor]
     )
 
     available_measurements = discovery_client.enumerate_services(

--- a/packages/service/tests/unit/test_discovery_client.py
+++ b/packages/service/tests/unit/test_discovery_client.py
@@ -17,6 +17,8 @@ from ni_measurement_plugin_sdk_service._annotations import (
     SERVICE_PROGRAMMINGLANGUAGE_KEY,
 )
 from ni_measurement_plugin_sdk_service._internal.stubs.ni.measurementlink.discovery.v1.discovery_service_pb2 import (
+    EnumerateServicesRequest,
+    EnumerateServicesResponse,
     RegisterServiceRequest,
     RegisterServiceResponse,
     ResolveServiceRequest,
@@ -24,8 +26,6 @@ from ni_measurement_plugin_sdk_service._internal.stubs.ni.measurementlink.discov
     ServiceLocation as GrpcServiceLocation,
     UnregisterServiceRequest,
     UnregisterServiceResponse,
-    EnumerateServicesRequest,
-    EnumerateServicesResponse,
 )
 from ni_measurement_plugin_sdk_service._internal.stubs.ni.measurementlink.discovery.v1.discovery_service_pb2_grpc import (
     DiscoveryServiceStub,
@@ -322,14 +322,13 @@ def test___discovery_service_exe_unavailable___register_service___raises_file_no
         discovery_client.register_service(_TEST_SERVICE_INFO, _TEST_SERVICE_LOCATION)
 
 
-def test___active_measurements_available___enumerate_services___returns_list_of_measurements(
+def test___registered_measurements___enumerate_services___returns_list_of_measurements(
     discovery_client: DiscoveryClient, discovery_service_stub: Mock
 ):
     discovery_service_stub.RegisterService.return_value = RegisterServiceResponse(
         registration_id="abcd"
     )
     discovery_client.register_service(_TEST_SERVICE_INFO, _TEST_SERVICE_LOCATION)
-    discovery_service_stub.RegisterService.assert_called_once()
     register_service_request: RegisterServiceRequest = (
         discovery_service_stub.RegisterService.call_args.args[0]
     )
@@ -348,7 +347,7 @@ def test___active_measurements_available___enumerate_services___returns_list_of_
         _assert_service_info_equal(_TEST_SERVICE_INFO, measurement)
 
 
-def test___no_active_measurements_available___enumerate_services___returns_list_of_measurements(
+def test___no_registered_measurements___enumerate_services___returns_empty_list(
     discovery_client: DiscoveryClient, discovery_service_stub: Mock
 ):
     discovery_service_stub.EnumerateServices.return_value = EnumerateServicesResponse()

--- a/packages/service/tests/unit/test_discovery_client.py
+++ b/packages/service/tests/unit/test_discovery_client.py
@@ -341,6 +341,7 @@ def test___registered_measurements___enumerate_services___returns_list_of_measur
                 provided_interfaces=expected_service_info.provided_interfaces,
                 annotations=expected_service_info.annotations,
                 service_class=expected_service_info.service_class,
+                versions=expected_service_info.versions
             )
         ]
     )

--- a/packages/service/tests/unit/test_discovery_client.py
+++ b/packages/service/tests/unit/test_discovery_client.py
@@ -90,8 +90,6 @@ _MOCK_REGISTRATION_FILE_CONTENT = {"discovery": {"path": "Discovery/NI.Discovery
 def test___service_not_registered___register_service___sends_request_and_returns_id(
     discovery_client: DiscoveryClient, discovery_service_stub: Mock
 ):
-    expected_service_info = copy.deepcopy(_TEST_SERVICE_INFO)
-    expected_service_info.annotations[SERVICE_PROGRAMMINGLANGUAGE_KEY] = "Python"
     discovery_service_stub.RegisterService.return_value = RegisterServiceResponse(
         registration_id="abcd"
     )
@@ -100,6 +98,8 @@ def test___service_not_registered___register_service___sends_request_and_returns
 
     discovery_service_stub.RegisterService.assert_called_once()
     request: RegisterServiceRequest = discovery_service_stub.RegisterService.call_args.args[0]
+    expected_service_info = copy.deepcopy(_TEST_SERVICE_INFO)
+    expected_service_info.annotations[SERVICE_PROGRAMMINGLANGUAGE_KEY] = "Python"
     _assert_service_info_equal(expected_service_info, request.service_description)
     _assert_service_location_equal(_TEST_SERVICE_LOCATION, request.location)
     assert registration_id == "abcd"
@@ -157,8 +157,6 @@ def test___service_not_registered___resolve_service___raises_not_found_error(
 def test___service_not_registered___register_measurement_service___sends_request_and_warns(
     discovery_client: DiscoveryClient, discovery_service_stub: Mock
 ):
-    expected_service_info = copy.deepcopy(_TEST_SERVICE_INFO)
-    expected_service_info.annotations[SERVICE_PROGRAMMINGLANGUAGE_KEY] = "Python"
     discovery_service_stub.RegisterService.return_value = RegisterServiceResponse(
         registration_id="abcd"
     )
@@ -170,6 +168,8 @@ def test___service_not_registered___register_measurement_service___sends_request
 
     discovery_service_stub.RegisterService.assert_called_once()
     request = discovery_service_stub.RegisterService.call_args.args[0]
+    expected_service_info = copy.deepcopy(_TEST_SERVICE_INFO)
+    expected_service_info.annotations[SERVICE_PROGRAMMINGLANGUAGE_KEY] = "Python"
     _assert_service_info_equal(expected_service_info, request.service_description)
     _assert_service_location_equal(_TEST_SERVICE_LOCATION_WITHOUT_SSL, request.location)
     assert discovery_client._registration_id == "abcd"
@@ -326,9 +326,8 @@ def test___discovery_service_exe_unavailable___register_service___raises_file_no
     with pytest.raises(FileNotFoundError):
         discovery_client.register_service(_TEST_SERVICE_INFO, _TEST_SERVICE_LOCATION)
 
-@pytest.mark.parametrize(
-    "programming_language", ["Python", "LabVIEW"]
-) # 
+
+@pytest.mark.parametrize("programming_language", ["Python", "LabVIEW"])
 def test___registered_measurements___enumerate_services___returns_list_of_measurements(
     discovery_client: DiscoveryClient, discovery_service_stub: Mock, programming_language: str
 ):
@@ -350,9 +349,11 @@ def test___registered_measurements___enumerate_services___returns_list_of_measur
 
     discovery_service_stub.EnumerateServices.assert_called_once()
     request: EnumerateServicesRequest = discovery_service_stub.EnumerateServices.call_args.args[0]
+    expected_service_info = copy.deepcopy(_TEST_SERVICE_INFO)
+    expected_service_info.annotations[SERVICE_PROGRAMMINGLANGUAGE_KEY] = programming_language
     assert _TEST_SERVICE_INFO.provided_interfaces[1] == request.provided_interface
     for measurement in available_measurements:
-        _assert_service_info_equal(grpc_service_descriptor, measurement)
+        _assert_service_info_equal(expected_service_info, measurement)
 
 
 def test___no_registered_measurements___enumerate_services___returns_empty_list(


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Implementation of the enumerate service API, which return the active measurement services
- Added automation test

### Why should this Pull Request be merged?

- This implementation supports the Interactive Approach for the [Measurement Plug-In client API](https://dev.azure.com/ni/DevCentral/_git/ASW?path=/Specs/Test%20Automation%20Frameworks/E2719769_Support%20for%20Measurement%20Plug-In%20client%20APIs/E2719769_Support%20for%20Measurement%20Plug-In%20client%20APIs.md&version=GBmain&_a=preview&anchor=interactive-approach)'s in python 

### What testing has been done?

Existing and new automated tests passed.