### PR TITLE
Update measurement service to get version from .serviceconfig

### DIFF
--- a/packages/generator/ni_measurement_plugin_sdk_generator/template.py
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/template.py
@@ -179,7 +179,6 @@ def create_measurement(
         "measurement.py",
         directory_out_path,
         display_name=display_name,
-        version=measurement_version,
         ui_file=ui_file,
         ui_file_type=ui_file_type,
         service_class=service_class,
@@ -196,6 +195,7 @@ def create_measurement(
         ui_file_type=ui_file_type,
         description=description,
         collection=collection,
+        version=measurement_version,
         tags=list(tags),
     )
     if ui_file_type == "MeasurementUI":

--- a/packages/generator/ni_measurement_plugin_sdk_generator/templates/measurement.py.mako
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/templates/measurement.py.mako
@@ -1,4 +1,4 @@
-<%page args="display_name, version, ui_file, ui_file_type, service_class, description_url, serviceconfig_file"/>\
+<%page args="display_name, ui_file, ui_file_type, service_class, description_url, serviceconfig_file"/>\
 \
 """A default measurement with an array in and out."""
 
@@ -13,7 +13,6 @@ script_or_exe = sys.executable if getattr(sys, "frozen", False) else __file__
 service_directory = pathlib.Path(script_or_exe).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "${serviceconfig_file}",
-    version="${version}",
     ui_file_paths=[service_directory / "${ui_file}"],
 )
 

--- a/packages/generator/ni_measurement_plugin_sdk_generator/templates/measurement.serviceconfig.mako
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/templates/measurement.serviceconfig.mako
@@ -1,4 +1,4 @@
-<%page args="display_name, service_class, description_url, description, collection, tags"/>\
+<%page args="display_name, service_class, description_url, description, collection, version, tags"/>\
 <%
     import json
 
@@ -13,6 +13,7 @@
                   "ni.measurementlink.measurement.v2.MeasurementService",
               ],
               "path": "start.bat",
+              "version": version,
               "annotations": {
                   "ni/service.description": description,
                   "ni/service.collection": collection,

--- a/packages/generator/tests/test_assets/example_renders/measurement/SampleMeasurement.serviceconfig
+++ b/packages/generator/tests/test_assets/example_renders/measurement/SampleMeasurement.serviceconfig
@@ -9,6 +9,7 @@
         "ni.measurementlink.measurement.v2.MeasurementService"
       ],
       "path": "start.bat",
+      "version": "1.2.3.4",
       "annotations": {
         "ni/service.description": "",
         "ni/service.collection": "",

--- a/packages/generator/tests/test_assets/example_renders/measurement/measurement.py
+++ b/packages/generator/tests/test_assets/example_renders/measurement/measurement.py
@@ -11,7 +11,6 @@ script_or_exe = sys.executable if getattr(sys, "frozen", False) else __file__
 service_directory = pathlib.Path(script_or_exe).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "SampleMeasurement.serviceconfig",
-    version="1.2.3.4",
     ui_file_paths=[service_directory / "MeasurementUI.measui"],
 )
 

--- a/packages/generator/tests/test_assets/example_renders/measurement_with_annotations/SampleMeasurement.serviceconfig
+++ b/packages/generator/tests/test_assets/example_renders/measurement_with_annotations/SampleMeasurement.serviceconfig
@@ -9,6 +9,7 @@
         "ni.measurementlink.measurement.v2.MeasurementService"
       ],
       "path": "start.bat",
+      "version": "1.2.3.4",
       "annotations": {
         "ni/service.description": "Measurement description",
         "ni/service.collection": "Measurement.Collection",

--- a/packages/generator/tests/test_assets/example_renders/measurement_with_annotations/measurement.py
+++ b/packages/generator/tests/test_assets/example_renders/measurement_with_annotations/measurement.py
@@ -11,7 +11,6 @@ script_or_exe = sys.executable if getattr(sys, "frozen", False) else __file__
 service_directory = pathlib.Path(script_or_exe).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "SampleMeasurement.serviceconfig",
-    version="1.2.3.4",
     ui_file_paths=[service_directory / "MeasurementUI.measui"],
 )
 

--- a/packages/service/ni_measurement_plugin_sdk_service/discovery/_client.py
+++ b/packages/service/ni_measurement_plugin_sdk_service/discovery/_client.py
@@ -124,6 +124,7 @@ class DiscoveryClient:
                 provided_interfaces=service_info.provided_interfaces,
                 service_class=service_info.service_class,
                 annotations=annotations,
+                versions=[service_info.version],
             )
 
             grpc_service_location = discovery_service_pb2.ServiceLocation(

--- a/packages/service/ni_measurement_plugin_sdk_service/discovery/_client.py
+++ b/packages/service/ni_measurement_plugin_sdk_service/discovery/_client.py
@@ -124,7 +124,7 @@ class DiscoveryClient:
                 provided_interfaces=service_info.provided_interfaces,
                 service_class=service_info.service_class,
                 annotations=annotations,
-                versions=[service_info.version],
+                versions=service_info.versions,
             )
 
             grpc_service_location = discovery_service_pb2.ServiceLocation(

--- a/packages/service/ni_measurement_plugin_sdk_service/measurement/info.py
+++ b/packages/service/ni_measurement_plugin_sdk_service/measurement/info.py
@@ -28,9 +28,9 @@ class ServiceInfo(NamedTuple):
     """
 
     service_class: str
-    """"The "class" of a service. The value of this field should be unique for a given interface
-    in ``provided_interfaces``. In effect, the ``.proto`` service declaration defines the
-    interface, and this field defines a class or concrete type of the interface."""
+    """"The "class" of a service. The value of this field should be unique for all services.
+    In effect, the ``.proto`` service declaration defines the interface, and this field
+    defines a class or concrete type of the interface."""
 
     description_url: str
     """The URL of a web page that provides a description of the service."""
@@ -40,7 +40,7 @@ class ServiceInfo(NamedTuple):
 
     annotations: Dict[str, str] = {}
     """Represents a set of annotations on the service.
-    
+
     Well-known annotations:
 
     - Description
@@ -60,6 +60,9 @@ class ServiceInfo(NamedTuple):
 
     display_name: str = ""
     """The service display name for clients to display to users."""
+
+    version: str = ""
+    """The version of the service.  It should be in the form major.minor.build[.revision] (e.g. 1.0.0)."""
 
 
 class TypeSpecialization(enum.Enum):

--- a/packages/service/ni_measurement_plugin_sdk_service/measurement/info.py
+++ b/packages/service/ni_measurement_plugin_sdk_service/measurement/info.py
@@ -62,7 +62,7 @@ class ServiceInfo(NamedTuple):
     """The service display name for clients to display to users."""
 
     version: str = ""
-    """The version of the service.  It should be in the form major.minor.build[.revision] (e.g. 1.0.0)."""
+    """The version of the service in the form major.minor.build[.revision] (e.g. 1.0.0)."""
 
 
 class TypeSpecialization(enum.Enum):

--- a/packages/service/ni_measurement_plugin_sdk_service/measurement/info.py
+++ b/packages/service/ni_measurement_plugin_sdk_service/measurement/info.py
@@ -61,8 +61,9 @@ class ServiceInfo(NamedTuple):
     display_name: str = ""
     """The service display name for clients to display to users."""
 
-    version: str = ""
-    """The version of the service in the form major.minor.build[.revision] (e.g. 1.0.0)."""
+    versions: List[str] = []
+    """The list of versions associated with this service in
+     the form major.minor.build[.revision] (e.g. 1.0.0)."""
 
 
 class TypeSpecialization(enum.Enum):

--- a/packages/service/ni_measurement_plugin_sdk_service/measurement/service.py
+++ b/packages/service/ni_measurement_plugin_sdk_service/measurement/service.py
@@ -241,7 +241,7 @@ class MeasurementService:
             service_class=service["serviceClass"],
             description_url=service["descriptionUrl"],
             provided_interfaces=service["providedInterfaces"],
-            version=version,
+            versions=[version],
             annotations={
                 key: convert_value_to_str(value)
                 for key, value in service.get("annotations", {}).items()

--- a/packages/service/ni_measurement_plugin_sdk_service/measurement/service.py
+++ b/packages/service/ni_measurement_plugin_sdk_service/measurement/service.py
@@ -177,8 +177,8 @@ class MeasurementService:
     def __init__(
         self,
         service_config_path: Path,
-        version: str,
-        ui_file_paths: List[Path],
+        version: Optional[str] = None,
+        ui_file_paths: List[Path] = [],
         service_class: Optional[str] = None,
     ) -> None:
         """Initialize the Measurement Service object.
@@ -215,6 +215,14 @@ class MeasurementService:
                 f"Service class '{service_class}' not found in '{service_config_file}'"
             )
 
+        config_version = service.get("version")
+        if config_version is not None:
+            if version is not None and version != config_version:
+                raise RuntimeError(
+                    f"Version mismatch: .serviceconfig version is '{config_version}', but version parameter is '{version}'.",
+                )
+            version = config_version
+
         # Note: sphinx-autoapi uses the public attributes' type hints and docstrings.
         self.measurement_info: MeasurementInfo = MeasurementInfo(
             display_name=service["displayName"],
@@ -233,6 +241,7 @@ class MeasurementService:
             service_class=service["serviceClass"],
             description_url=service["descriptionUrl"],
             provided_interfaces=service["providedInterfaces"],
+            version=version,
             annotations={
                 key: convert_value_to_str(value)
                 for key, value in service.get("annotations", {}).items()

--- a/packages/service/ni_measurement_plugin_sdk_service/measurement/service.py
+++ b/packages/service/ni_measurement_plugin_sdk_service/measurement/service.py
@@ -189,9 +189,12 @@ class MeasurementService:
         Args:
             service_config_path (Path): Path to the .serviceconfig file.
 
-            version (str): Version of the measurement service.
+            version (str): Version of the measurement service. Do not use this
+                parameter.  Instead, specify the "version" field in the
+                .serviceconfig file. Default value is "".
 
             ui_file_paths (List[Path]): List of paths to supported UIs.
+                Default value is [].
 
             service_class (str): The service class from the .serviceconfig to use.
                 Default value is None, which will use the first service in the

--- a/packages/service/ni_measurement_plugin_sdk_service/measurement/service.py
+++ b/packages/service/ni_measurement_plugin_sdk_service/measurement/service.py
@@ -177,7 +177,7 @@ class MeasurementService:
     def __init__(
         self,
         service_config_path: Path,
-        version: Optional[str] = None,
+        version: str = "",
         ui_file_paths: List[Path] = [],
         service_class: Optional[str] = None,
     ) -> None:
@@ -217,7 +217,7 @@ class MeasurementService:
 
         config_version = service.get("version")
         if config_version is not None:
-            if version is not None and version != config_version:
+            if version and version != config_version:
                 raise RuntimeError(
                     f"Version mismatch: .serviceconfig version is '{config_version}', but version parameter is '{version}'.",
                 )

--- a/packages/service/tests/assets/example.AllAnnotations.serviceconfig
+++ b/packages/service/tests/assets/example.AllAnnotations.serviceconfig
@@ -8,6 +8,7 @@
         "ni.measurementlink.measurement.v2.MeasurementService"
       ],
       "path": "start.bat",
+      "version": "1.0.6",
       "annotations": {
         "ni/service.description": "Testing extra Client info",
         "client/extra.NumberID" : 500,

--- a/packages/service/tests/assets/example.CustomAnnotations.serviceconfig
+++ b/packages/service/tests/assets/example.CustomAnnotations.serviceconfig
@@ -5,9 +5,10 @@
       "serviceClass": "SampleMeasurement_Python",
       "descriptionUrl": "https://www.example.com/SampleMeasurement.html",
       "providedInterfaces": [
-         "ni.measurementlink.measurement.v1.MeasurementService"
+        "ni.measurementlink.measurement.v1.MeasurementService"
       ],
       "path": "NoFile.exe",
+      "version": "1.0.7",
       "annotations": {
         "description": "An annotated test measurement service.",
         "collection": "Tests.Measurements",

--- a/packages/service/tests/assets/example.OnlyCollection.serviceconfig
+++ b/packages/service/tests/assets/example.OnlyCollection.serviceconfig
@@ -9,6 +9,7 @@
         "ni.measurementlink.measurement.v2.MeasurementService"
       ],
       "path": "start.bat",
+      "version": "1.0.4",
       "annotations": {
         "ni/service.collection": "CurrentTests.Inrush"
       }

--- a/packages/service/tests/assets/example.OnlyTags.serviceconfig
+++ b/packages/service/tests/assets/example.OnlyTags.serviceconfig
@@ -8,6 +8,7 @@
         "ni.measurementlink.measurement.v2.MeasurementService"
       ],
       "path": "start.bat",
+      "version": "1.0.5",
       "annotations": {
         "ni/service.tags": [ "powerup", "current", "voltage" ]
       }

--- a/packages/service/tests/assets/example.serviceconfig
+++ b/packages/service/tests/assets/example.serviceconfig
@@ -9,6 +9,7 @@
         "ni.measurementlink.measurement.v2.MeasurementService"
       ],
       "path": "start.bat",
+      "version": "1.0.1",
       "annotations": {
         "ni/service.description": "Measure inrush current with a shorted load and validate results against configured limits.",
         "ni/service.collection": "CurrentTests.Inrush",

--- a/packages/service/tests/assets/example.v2.serviceconfig
+++ b/packages/service/tests/assets/example.v2.serviceconfig
@@ -7,7 +7,8 @@
       "providedInterfaces": [
         "ni.measurementlink.measurement.v2.MeasurementService"
       ],
-      "path": "start.bat"
+      "path": "start.bat",
+      "version": "1.0.3"
     }
   ]
 }

--- a/packages/service/tests/unit/test_discovery_client.py
+++ b/packages/service/tests/unit/test_discovery_client.py
@@ -394,7 +394,4 @@ def _assert_service_info_equal(
     assert set(expected.provided_interfaces) == set(actual.provided_interfaces)
     assert expected.service_class == actual.service_class
     assert expected.annotations == actual.annotations
-    if isinstance(actual, GrpcServiceDescriptor):
-        assert expected.versions == actual.versions
-    else:
-        assert expected.versions == actual.versions
+    assert expected.versions == actual.versions

--- a/packages/service/tests/unit/test_discovery_client.py
+++ b/packages/service/tests/unit/test_discovery_client.py
@@ -65,11 +65,12 @@ _TEST_SERVICE_LOCATION = ServiceLocation("localhost", _TEST_SERVICE_PORT, _TEST_
 _TEST_SERVICE_LOCATION_WITHOUT_SSL = _TEST_SERVICE_LOCATION._replace(ssl_authenticated_port="")
 
 _TEST_SERVICE_INFO = ServiceInfo(
-    "TestServiceClass",
-    "TestUrl",
-    _PROVIDED_MEASUREMENT_SERVICES,
-    _PROVIDED_ANNOTATIONS,
-    "TestMeasurement",
+    service_class="TestServiceClass",
+    description_url="TestUrl",
+    provided_interfaces=_PROVIDED_MEASUREMENT_SERVICES,
+    annotations=_PROVIDED_ANNOTATIONS,
+    display_name="TestMeasurement",
+    version="2.0.2",
 )
 _TEST_SERVICE_INFO_WITHOUT_DISPLAY_NAME = _TEST_SERVICE_INFO._replace(display_name="")
 
@@ -393,3 +394,7 @@ def _assert_service_info_equal(
     assert set(expected.provided_interfaces) == set(actual.provided_interfaces)
     assert expected.service_class == actual.service_class
     assert expected.annotations == actual.annotations
+    if isinstance(actual, GrpcServiceDescriptor):
+        assert expected.version == actual.versions[0]
+    else:
+        assert expected.version == actual.version

--- a/packages/service/tests/unit/test_discovery_client.py
+++ b/packages/service/tests/unit/test_discovery_client.py
@@ -70,7 +70,7 @@ _TEST_SERVICE_INFO = ServiceInfo(
     provided_interfaces=_PROVIDED_MEASUREMENT_SERVICES,
     annotations=_PROVIDED_ANNOTATIONS,
     display_name="TestMeasurement",
-    version="2.0.2",
+    versions=["2.0.2"],
 )
 _TEST_SERVICE_INFO_WITHOUT_DISPLAY_NAME = _TEST_SERVICE_INFO._replace(display_name="")
 
@@ -395,6 +395,6 @@ def _assert_service_info_equal(
     assert expected.service_class == actual.service_class
     assert expected.annotations == actual.annotations
     if isinstance(actual, GrpcServiceDescriptor):
-        assert expected.version == actual.versions[0]
+        assert expected.versions == actual.versions
     else:
-        assert expected.version == actual.version
+        assert expected.versions == actual.versions

--- a/packages/service/tests/unit/test_service.py
+++ b/packages/service/tests/unit/test_service.py
@@ -360,7 +360,7 @@ no_annotations: typing.Dict[str, str] = {}
         ),
         (
             "example.v1.serviceconfig",
-            None,
+            "",
             ["ni.measurementlink.measurement.v1.MeasurementService"],
             no_annotations,
         ),

--- a/packages/service/tests/unit/test_service.py
+++ b/packages/service/tests/unit/test_service.py
@@ -343,10 +343,11 @@ no_annotations: typing.Dict[str, str] = {}
 
 
 @pytest.mark.parametrize(
-    "service_config,provided_interfaces,provided_annotations",
+    "service_config,version,provided_interfaces,provided_annotations",
     [
         (
             "example.serviceconfig",
+            "1.0.1",
             [
                 "ni.measurementlink.measurement.v1.MeasurementService",
                 "ni.measurementlink.measurement.v2.MeasurementService",
@@ -359,26 +360,31 @@ no_annotations: typing.Dict[str, str] = {}
         ),
         (
             "example.v1.serviceconfig",
+            None,
             ["ni.measurementlink.measurement.v1.MeasurementService"],
             no_annotations,
         ),
         (
             "example.v2.serviceconfig",
+            "1.0.3",
             ["ni.measurementlink.measurement.v2.MeasurementService"],
             no_annotations,
         ),
         (
             "example.OnlyCollection.serviceconfig",
+            "1.0.4",
             ["ni.measurementlink.measurement.v2.MeasurementService"],
             {"ni/service.collection": "CurrentTests.Inrush"},
         ),
         (
             "example.OnlyTags.serviceconfig",
+            "1.0.5",
             ["ni.measurementlink.measurement.v2.MeasurementService"],
             {"ni/service.tags": '["powerup","current","voltage"]'},
         ),
         (
             "example.AllAnnotations.serviceconfig",
+            "1.0.6",
             ["ni.measurementlink.measurement.v2.MeasurementService"],
             {
                 "ni/service.description": "Testing extra Client info",
@@ -389,6 +395,7 @@ no_annotations: typing.Dict[str, str] = {}
         ),
         (
             "example.CustomAnnotations.serviceconfig",
+            "1.0.7",
             ["ni.measurementlink.measurement.v1.MeasurementService"],
             {
                 "description": "An annotated test measurement service.",
@@ -403,15 +410,16 @@ no_annotations: typing.Dict[str, str] = {}
 def test___service_config___create_measurement_service___service_info_matches_service_config(
     test_assets_directory: pathlib.Path,
     service_config: str,
+    version: str,
     provided_interfaces: List[str],
     provided_annotations: typing.Dict[str, str],
 ):
     measurement_service = MeasurementService(
         service_config_path=test_assets_directory / service_config,
-        version="1.0.0.0",
         ui_file_paths=[],
     )
 
+    assert measurement_service.service_info.version == version
     assert measurement_service.service_info.service_class == "SampleMeasurement_Python"
     assert set(measurement_service.service_info.provided_interfaces) >= set(provided_interfaces)
     assert (
@@ -419,6 +427,38 @@ def test___service_config___create_measurement_service___service_info_matches_se
         == "https://www.example.com/SampleMeasurement.html"
     )
     assert measurement_service.service_info.annotations == provided_annotations
+
+
+def test___service_config___create_measurement_service_with_version___version_differs_from_service_config(
+    test_assets_directory: pathlib.Path,
+):
+    with pytest.raises(RuntimeError) as version_error:
+        MeasurementService(
+            service_config_path=test_assets_directory / "example.serviceconfig",
+            version="2.0.1",
+        )
+
+    assert "Version mismatch" in str(version_error.value)
+
+
+@pytest.mark.parametrize(
+    "service_config,version",
+    [
+        ("example.serviceconfig", "1.0.1"),
+        ("example.v1.serviceconfig", "2.0.1"),
+    ],
+)
+def test___service_config___create_measurement_service_with_version___version_is_used(
+    test_assets_directory: pathlib.Path,
+    service_config: str,
+    version: str,
+):
+    service = MeasurementService(
+        service_config_path=test_assets_directory / service_config,
+        version=version,
+    )
+
+    assert service.service_info.version == version
 
 
 @pytest.mark.parametrize(
@@ -458,8 +498,4 @@ def test___measurement_service___host_service_with_grpc_service_not_started___ra
 @pytest.fixture
 def measurement_service(test_assets_directory: pathlib.Path) -> MeasurementService:
     """Create a MeasurementService."""
-    return MeasurementService(
-        service_config_path=test_assets_directory / "example.serviceconfig",
-        version="1.0.0.0",
-        ui_file_paths=[],
-    )
+    return MeasurementService(service_config_path=test_assets_directory / "example.serviceconfig")

--- a/packages/service/tests/unit/test_service.py
+++ b/packages/service/tests/unit/test_service.py
@@ -419,7 +419,7 @@ def test___service_config___create_measurement_service___service_info_matches_se
         ui_file_paths=[],
     )
 
-    assert measurement_service.service_info.version == version
+    assert measurement_service.service_info.versions[0] == version
     assert measurement_service.service_info.service_class == "SampleMeasurement_Python"
     assert set(measurement_service.service_info.provided_interfaces) >= set(provided_interfaces)
     assert (
@@ -458,7 +458,7 @@ def test___service_config___create_measurement_service_with_version___version_is
         version=version,
     )
 
-    assert service.service_info.version == version
+    assert service.service_info.versions[0] == version
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Add support for reading a measurement's version from its `.serviceconfig` file, as well as passing that version through discovery service's `RegisterService` API.

To do this:
- Make `version` and `ui_file_paths` parameters to the `MeasurementService` constructor optional
- If version is specified in the constructor, use it unless it is also specified in the `.serviceconfig` file AND the two values are different. If the values are different, raise an error
- Add a `version` property to `ServiceInfo`
- Pass `ServiceInfo.version` through the `RegisterServiceRequest` inside the `DiscoveryClient`.

### Why should this Pull Request be merged?

We're working to add version support to our plugins.  The intention is for the version of a plugin to be stored in its `.serviceconfig` file and passed to discovery service when it registers itself.

### What testing has been done?

A couple new tests have been written, and a couple existing tests have been updated to account for the presence of a version in the service config.