### PR TITLE
example: use the tuple with the updated "in_compliance" value returned by _replace()

### DIFF
--- a/examples/nidcpower_source_dc_voltage/measurement.py
+++ b/examples/nidcpower_source_dc_voltage/measurement.py
@@ -123,9 +123,7 @@ def measure(
                         in_compliance = session_info.session.channels[
                             channel_mapping.channel
                         ].query_in_compliance()
-                        measurement._replace(in_compliance=in_compliance)
-
-                    measurements.extend(session_measurements)
+                        measurements.append(measurement._replace(in_compliance=in_compliance))
 
                 # Reset the channels to a known state
                 for session_info in session_infos:


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?
* While expanding the `nidcpower_source_dc_voltage` measurement to support multisite in #676, I overlooked the update to the `in_compliance` value in the `_Measurement` tuple. Since tuples are immutable, invoking `_replace()` on a tuple doesn't modify the original tuple; instead, it returns a new tuple with the updated values.
* In the current implementation, the object returned by the `_replace()` method wasn't captured or assigned to any variable, resulting in the use of the original tuple, which did not have the correct "in_compliance" value. This PR ensures that the tuple returned by the `_replace()` method is properly appended to the final `measurements` list.

### Why should this Pull Request be merged?
* Fixes the bug where the `in_compliance` value was not assigned properly.

### What testing has been done?
* Manually verified by running the measurement.