### PR TITLE
renovate: Automatically update ni-apis submodule

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,5 +6,15 @@
     ":maintainLockFilesWeekly",
     ":automergePatch",
     "schedule:automergeDaily"
+  ],
+  "git-submodules": {
+    "automerge": true,
+    "enabled": true
+  },
+  "packageRules": [
+    {
+      "matchDepNames": ["third_party/ni-apis"],
+      "extends": ["schedule:weekly"]
+    }
   ]
 }


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Configure Renovate to update Git submodules.

Specify a weekly schedule for updating `third_party/ni-apis`, so it doesn't update for every upstream commit.

### Why should this Pull Request be merged?

Keep `ni-apis` up to date and notify us (via PR build failure) when the checked-in gRPC stubs need to be updated.

When a contributor needs to update `ni-apis` for a new feature, they shouldn't have to deal with past `ni-apis` changes cluttering the diff and/or causing issues.

### What testing has been done?

None