### PR TITLE
github: Upgrade upload-artifact and download-artifact to v4

### DIFF
--- a/.github/workflows/report_test_results.yml
+++ b/.github/workflows/report_test_results.yml
@@ -16,10 +16,11 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v4
       - name: Download test results
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: test_results
           path: test_results
+          pattern: test_results_*
+          merge-multiple: true
       - name: List downloaded files
         run: ls -lR
       - name: Publish test results

--- a/.github/workflows/run_system_tests.yml
+++ b/.github/workflows/run_system_tests.yml
@@ -42,8 +42,8 @@ jobs:
       - name: Run system tests
         run: poetry run tox
       - name: Upload test results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: test_results
+          name: test_results_system_${{ matrix.configuration }}
           path: ./packages/service/test_results/*.xml
         if: always()

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -92,8 +92,8 @@ jobs:
         working-directory: ./packages/generator
 
       - name: Upload test results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: test_results
+          name: test_results_unit_${{ matrix.os }}_py${{ matrix.python-version }}
           path: ./packages/service/test_results/*.xml
         if: always()


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Upgrade `actions/upload-artifact` and `actions/download-artifact` to v4. 

Artifacts are now immutable, so upload a separate artifact per test run and merge them when downloading.

### Why should this Pull Request be merged?

The old version is scheduled for deprecation and uses a deprecated Node.js version.

### What testing has been done?

PR build