### PR TITLE
Add Cancel API to Measurement Plug-In Client

### DIFF
--- a/packages/generator/ni_measurement_plugin_sdk_generator/client/templates/measurement_plugin_client.py.mako
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/client/templates/measurement_plugin_client.py.mako
@@ -172,7 +172,7 @@ class ${class_name}:
         )
         for response in stream_measure_response:
             result = response
-        return result          
+        return result
 
     def stream_measure(
         self,

--- a/packages/generator/ni_measurement_plugin_sdk_generator/client/templates/measurement_plugin_client.py.mako
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/client/templates/measurement_plugin_client.py.mako
@@ -173,8 +173,8 @@ class ${class_name}:
         
         try:
             for response in self._measure_response:
-                result = self._deserialize_response(response)
-            return result
+                result = response
+            return self._deserialize_response(result)
         except grpc.RpcError as e:
             if e.code() == grpc.StatusCode.CANCELLED:
                 print("Measure call has been cancelled.")

--- a/packages/generator/ni_measurement_plugin_sdk_generator/client/templates/measurement_plugin_client.py.mako
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/client/templates/measurement_plugin_client.py.mako
@@ -192,8 +192,7 @@ class ${class_name}:
         parameter_values = [${measure_api_parameters}]
         with self._initialization_lock:
             if self._measure_response is not None:
-                print("A measure call is already in progress.")
-                return
+                raise RuntimeError("A measure call is already in progress.")
             request = self._create_measure_request(parameter_values)
             self._measure_response = self._get_stub().Measure(request)
 

--- a/packages/generator/ni_measurement_plugin_sdk_generator/client/templates/measurement_plugin_client.py.mako
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/client/templates/measurement_plugin_client.py.mako
@@ -174,9 +174,6 @@ class ${class_name}:
         stream_measure_response = self.stream_measure(
             ${measure_api_parameters}
         )
-        % if output_metadata:
-        result = None
-        % endif
         for response in stream_measure_response:
         % if output_metadata:
             result = response
@@ -197,7 +194,9 @@ class ${class_name}:
         parameter_values = [${measure_api_parameters}]
         with self._initialization_lock:
             if self._measure_response is not None:
-                raise RuntimeError("A measure call is already in progress.")
+                raise RuntimeError(
+                    "A measurement is currently in progress. To make concurrent measurement requests, please create a new client instance."
+                )
             request = self._create_measure_request(parameter_values)
             self._measure_response = self._get_stub().Measure(request)
 
@@ -210,9 +209,8 @@ class ${class_name}:
                 % endif
         except grpc.RpcError as e:
             if e.code() == grpc.StatusCode.CANCELLED:
-                _logger.debug("The measure call is canceled.")
-            else:
-                raise
+                _logger.debug("The measurement is canceled.")
+            raise
         finally:
             with self._initialization_lock:
                 self._measure_response = None

--- a/packages/generator/ni_measurement_plugin_sdk_generator/client/templates/measurement_plugin_client.py.mako
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/client/templates/measurement_plugin_client.py.mako
@@ -169,13 +169,9 @@ class ${class_name}:
         Returns:
             Measurement outputs.
         """
-        with self._initialization_lock:
-            if self._measure_response is not None:
-                print("A measure call is already in progress.")
-                return
-            stream_measure_response = self.stream_measure(
-                ${measure_api_parameters}
-            )
+        stream_measure_response = self.stream_measure(
+            ${measure_api_parameters}
+        )
         for response in stream_measure_response:
         % if output_metadata:
             result = response
@@ -201,20 +197,20 @@ class ${class_name}:
             request = self._create_measure_request(parameter_values)
             self._measure_response = self._get_stub().Measure(request)
 
-        try:
-            for response in self._measure_response:
-                % if output_metadata:
-                yield self._deserialize_response(response)
-                % else:
-                yield
-                % endif
-        except grpc.RpcError as e:
-            if e.code() == grpc.StatusCode.CANCELLED:
-                print("The measure call is canceled.")
-            else:
-                raise
-        finally:
-            self._measure_response = None
+            try:
+                for response in self._measure_response:
+                    % if output_metadata:
+                    yield self._deserialize_response(response)
+                    % else:
+                    yield
+                    % endif
+            except grpc.RpcError as e:
+                if e.code() == grpc.StatusCode.CANCELLED:
+                    print("The measure call is canceled.")
+                else:
+                    raise
+            finally:
+                self._measure_response = None
 
     def cancel(self) -> None:
         if self._measure_response and self._measure_response.is_active():

--- a/packages/generator/ni_measurement_plugin_sdk_generator/client/templates/measurement_plugin_client.py.mako
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/client/templates/measurement_plugin_client.py.mako
@@ -216,7 +216,7 @@ class ${class_name}:
                 self._measure_response = None
 
     def cancel(self) -> bool:
-        """Cancels the active measure call."""
+        """Cancels the active measurement call."""
         with self._initialization_lock:
             if self._measure_response:
                 return self._measure_response.cancel()

--- a/packages/generator/ni_measurement_plugin_sdk_generator/client/templates/measurement_plugin_client.py.mako
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/client/templates/measurement_plugin_client.py.mako
@@ -167,19 +167,12 @@ class ${class_name}:
         Returns:
             Measurement outputs.
         """
-        parameter_values = [${measure_api_parameters}]
-        request = self._create_measure_request(parameter_values)
-        self._measure_response = self._get_stub().Measure(request)
-        
-        try:
-            for response in self._measure_response:
-                result = response
-            return self._deserialize_response(result)
-        except grpc.RpcError as e:
-            if e.code() == grpc.StatusCode.CANCELLED:
-                print("Measure call has been cancelled.")
-            else:
-                raise           
+        stream_measure_response = self.stream_measure(
+            ${measure_api_parameters}
+        )
+        for response in stream_measure_response:
+            result = response
+        return result          
 
     def stream_measure(
         self,

--- a/packages/generator/tests/acceptance/test_non_streaming_measurement_client.py
+++ b/packages/generator/tests/acceptance/test_non_streaming_measurement_client.py
@@ -15,7 +15,7 @@ def test___measurement_plugin_client___measure___returns_output(
     measurement_plugin_client_module: ModuleType,
 ) -> None:
     test_measurement_client_type = getattr(measurement_plugin_client_module, "TestMeasurement")
-    output_type = getattr(measurement_plugin_client_module, "Output")
+    output_type = getattr(measurement_plugin_client_module, "Outputs")
     expected_output = output_type(
         float_out=0.05999999865889549,
         double_array_out=[0.1, 0.2, 0.3],
@@ -40,7 +40,7 @@ def test___measurement_plugin_client___stream_measure___returns_output(
     measurement_plugin_client_module: ModuleType,
 ) -> None:
     test_measurement_client_type = getattr(measurement_plugin_client_module, "TestMeasurement")
-    output_type = getattr(measurement_plugin_client_module, "Output")
+    output_type = getattr(measurement_plugin_client_module, "Outputs")
     expected_output = output_type(
         float_out=0.05999999865889549,
         double_array_out=[0.1, 0.2, 0.3],

--- a/packages/generator/tests/acceptance/test_streaming_measurement_client.py
+++ b/packages/generator/tests/acceptance/test_streaming_measurement_client.py
@@ -77,7 +77,7 @@ def test___non_streaming_measurement_execution___cancel___cancels_measure_call(
     measurement_plugin_client = test_measurement_client_type()
     measure_thread = threading.Thread(target=measurement_plugin_client.measure)
     measure_thread.start()
-    time.sleep(2) # Wait for 2 seconds to call Cancel API.
+    time.sleep(2)  # Wait for 2 seconds to call Cancel API.
 
     measurement_plugin_client.cancel()
 
@@ -96,7 +96,7 @@ def test___streaming_measurement_execution___cancel___cancels_stream_measure_cal
         target=lambda: tuple(measurement_plugin_client.stream_measure())
     )
     measure_thread.start()
-    time.sleep(2) # Wait for 2 seconds to call Cancel API.
+    time.sleep(2)  # Wait for 2 seconds to call Cancel API.
 
     measurement_plugin_client.cancel()
 

--- a/packages/generator/tests/acceptance/test_streaming_measurement_client.py
+++ b/packages/generator/tests/acceptance/test_streaming_measurement_client.py
@@ -17,7 +17,7 @@ def test___measurement_plugin_client___measure___returns_output(
     measurement_plugin_client_module: ModuleType,
 ) -> None:
     test_measurement_client_type = getattr(measurement_plugin_client_module, "TestMeasurement")
-    output_type = getattr(measurement_plugin_client_module, "Output")
+    output_type = getattr(measurement_plugin_client_module, "Outputs")
     expected_output = output_type(
         name="<Name>",
         index=9,
@@ -34,7 +34,7 @@ def test___measurement_plugin_client___stream_measure___returns_output(
     measurement_plugin_client_module: ModuleType,
 ) -> None:
     test_measurement_client_type = getattr(measurement_plugin_client_module, "TestMeasurement")
-    output_type = getattr(measurement_plugin_client_module, "Output")
+    output_type = getattr(measurement_plugin_client_module, "Outputs")
     measurement_plugin_client = test_measurement_client_type()
 
     response_iterator = measurement_plugin_client.stream_measure()

--- a/packages/generator/tests/acceptance/test_streaming_measurement_client.py
+++ b/packages/generator/tests/acceptance/test_streaming_measurement_client.py
@@ -59,7 +59,7 @@ def test___measurement_plugin_client___cancel___cancels_measure_call(
     measurement_plugin_client = test_measurement_client_type()
     measure_thread = threading.Thread(target=measurement_plugin_client.measure)
     measure_thread.start()
-    # Calls Cancel API after 2 seconds.
+    # Wait for 2 seconds to call Cancel API.
     time.sleep(2)
 
     measurement_plugin_client.cancel()
@@ -79,7 +79,7 @@ def test___measurement_plugin_client___cancel___cancels_stream_measure_call(
         target=lambda: list(map(lambda i: print(i), measurement_plugin_client.stream_measure()))
     )
     measure_thread.start()
-    # Calls Cancel API after 2 seconds.
+    # Wait for 2 seconds to call Cancel API.
     time.sleep(2)
 
     measurement_plugin_client.cancel()

--- a/packages/generator/tests/acceptance/test_streaming_measurement_client.py
+++ b/packages/generator/tests/acceptance/test_streaming_measurement_client.py
@@ -51,7 +51,7 @@ def test___measurement_plugin_client___stream_measure___returns_output(
     assert responses == expected_output
 
 
-def test___measurement_plugin_client___cancel___cancels_measure_call(
+def test___non_streaming_measurement_execution___cancel___cancels_measure_call(
     measurement_plugin_client_module: ModuleType,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
@@ -69,7 +69,7 @@ def test___measurement_plugin_client___cancel___cancels_measure_call(
     assert "Measure call has been cancelled." in captured.out
 
 
-def test___measurement_plugin_client___cancel___cancels_stream_measure_call(
+def test___streaming_measurement_execution___cancel___cancels_stream_measure_call(
     measurement_plugin_client_module: ModuleType,
     capsys: pytest.CaptureFixture[str],
 ) -> None:

--- a/packages/generator/tests/acceptance/test_streaming_measurement_client.py
+++ b/packages/generator/tests/acceptance/test_streaming_measurement_client.py
@@ -58,15 +58,13 @@ def test___measurement_plugin_client___invoke_measure_from_two_threads___initiat
     test_measurement_client_type = getattr(measurement_plugin_client_module, "TestMeasurement")
     measurement_plugin_client = test_measurement_client_type()
 
-    measure_thread_1 = threading.Thread(target=measurement_plugin_client.measure)
-    measure_thread_2 = threading.Thread(target=measurement_plugin_client.measure)
-    measure_thread_1.start()
-    measure_thread_2.start()
+    with pytest.raises(RuntimeError) as exc_info:
+        measure_thread = threading.Thread(target=measurement_plugin_client.measure)
+        measure_thread.start()
+        measurement_plugin_client.measure()  # Calling Measure in main thread, to catch error in pytest.
+        measure_thread.join()
 
-    measure_thread_1.join()
-    measure_thread_2.join()
-    captured = capsys.readouterr()
-    assert "A measure call is already in progress." in captured.out
+    assert "A measure call is already in progress." in exc_info.value.args[0]
 
 
 def test___non_streaming_measurement_execution___cancel___returns_true(

--- a/packages/generator/tests/acceptance/test_streaming_measurement_client.py
+++ b/packages/generator/tests/acceptance/test_streaming_measurement_client.py
@@ -53,7 +53,6 @@ def test___measurement_plugin_client___stream_measure___returns_output(
 
 def test___measurement_plugin_client___invoke_measure_from_two_threads___initiates_first_measure_and_rejects_second_measure(
     measurement_plugin_client_module: ModuleType,
-    capsys: pytest.CaptureFixture[str],
 ) -> None:
     test_measurement_client_type = getattr(measurement_plugin_client_module, "TestMeasurement")
     measurement_plugin_client = test_measurement_client_type()

--- a/packages/generator/tests/acceptance/test_streaming_measurement_client.py
+++ b/packages/generator/tests/acceptance/test_streaming_measurement_client.py
@@ -69,9 +69,8 @@ def test___measurement_plugin_client___invoke_measure_from_two_threads___initiat
     assert "A measure call is already in progress." in captured.out
 
 
-def test___non_streaming_measurement_execution___cancel___cancels_measure_call(
+def test___non_streaming_measurement_execution___cancel___returns_true(
     measurement_plugin_client_module: ModuleType,
-    capsys: pytest.CaptureFixture[str],
 ) -> None:
     test_measurement_client_type = getattr(measurement_plugin_client_module, "TestMeasurement")
     measurement_plugin_client = test_measurement_client_type()
@@ -79,16 +78,14 @@ def test___non_streaming_measurement_execution___cancel___cancels_measure_call(
     measure_thread.start()
     time.sleep(2)  # Wait for 2 seconds to call Cancel API.
 
-    measurement_plugin_client.cancel()
+    is_canceled = measurement_plugin_client.cancel()
 
     measure_thread.join()
-    captured = capsys.readouterr()
-    assert "The measure call is canceled." in captured.out
+    assert is_canceled
 
 
-def test___streaming_measurement_execution___cancel___cancels_stream_measure_call(
+def test___streaming_measurement_execution___cancel___returns_true(
     measurement_plugin_client_module: ModuleType,
-    capsys: pytest.CaptureFixture[str],
 ) -> None:
     test_measurement_client_type = getattr(measurement_plugin_client_module, "TestMeasurement")
     measurement_plugin_client = test_measurement_client_type()
@@ -98,24 +95,21 @@ def test___streaming_measurement_execution___cancel___cancels_stream_measure_cal
     measure_thread.start()
     time.sleep(2)  # Wait for 2 seconds to call Cancel API.
 
-    measurement_plugin_client.cancel()
+    is_canceled = measurement_plugin_client.cancel()
 
     measure_thread.join()
-    captured = capsys.readouterr()
-    assert "The measure call is canceled." in captured.out
+    assert is_canceled
 
 
-def test___cancel_measure_without_any_measure_calls___cancel___print_cancel_failure_message(
+def test___measurement_client___cancel_without__measure___returns_false(
     measurement_plugin_client_module: ModuleType,
-    capsys: pytest.CaptureFixture[str],
 ) -> None:
     test_measurement_client_type = getattr(measurement_plugin_client_module, "TestMeasurement")
     measurement_plugin_client = test_measurement_client_type()
 
-    measurement_plugin_client.cancel()
+    is_canceled = measurement_plugin_client.cancel()
 
-    captured = capsys.readouterr()
-    assert "The measure call is not initialized at this moment." in captured.out
+    assert not is_canceled
 
 
 @pytest.fixture(scope="module")

--- a/packages/generator/tests/acceptance/test_streaming_measurement_client.py
+++ b/packages/generator/tests/acceptance/test_streaming_measurement_client.py
@@ -51,6 +51,22 @@ def test___measurement_plugin_client___stream_measure___returns_output(
     assert responses == expected_output
 
 
+def test___call_measure_in_differnet_threads___measure___print_process_in_progress_message(
+    measurement_plugin_client_module: ModuleType,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    test_measurement_client_type = getattr(measurement_plugin_client_module, "TestMeasurement")
+    measurement_plugin_client = test_measurement_client_type()
+
+    measure_thread = threading.Thread(target=measurement_plugin_client.measure)
+    measure_thread.start()
+    measurement_plugin_client.measure()
+
+    measure_thread.join()
+    captured = capsys.readouterr()
+    assert "A measure call is already in progress." in captured.out
+
+
 def test___non_streaming_measurement_execution___cancel___cancels_measure_call(
     measurement_plugin_client_module: ModuleType,
     capsys: pytest.CaptureFixture[str],
@@ -66,7 +82,7 @@ def test___non_streaming_measurement_execution___cancel___cancels_measure_call(
 
     measure_thread.join()
     captured = capsys.readouterr()
-    assert "Measure call has been cancelled." in captured.out
+    assert "The measure call is canceled." in captured.out
 
 
 def test___streaming_measurement_execution___cancel___cancels_stream_measure_call(
@@ -86,7 +102,20 @@ def test___streaming_measurement_execution___cancel___cancels_stream_measure_cal
 
     measure_thread.join()
     captured = capsys.readouterr()
-    assert "Measure call has been cancelled." in captured.out
+    assert "The measure call is canceled." in captured.out
+
+
+def test___cancel_measure_without_any_measure_calls___cancel___print_cancel_failure_message(
+    measurement_plugin_client_module: ModuleType,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    test_measurement_client_type = getattr(measurement_plugin_client_module, "TestMeasurement")
+    measurement_plugin_client = test_measurement_client_type()
+
+    measurement_plugin_client.cancel()
+
+    captured = capsys.readouterr()
+    assert "The measure call is not initialized at this moment." in captured.out
 
 
 @pytest.fixture(scope="module")

--- a/packages/generator/tests/acceptance/test_streaming_measurement_client.py
+++ b/packages/generator/tests/acceptance/test_streaming_measurement_client.py
@@ -51,7 +51,7 @@ def test___measurement_plugin_client___stream_measure___returns_output(
     assert responses == expected_output
 
 
-def test___measurement_plugin_client___cancel___cancels_grpc_call(
+def test___measurement_plugin_client___cancel___cancels_measure_call(
     measurement_plugin_client_module: ModuleType,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
@@ -59,6 +59,27 @@ def test___measurement_plugin_client___cancel___cancels_grpc_call(
     measurement_plugin_client = test_measurement_client_type()
     measure_thread = threading.Thread(target=measurement_plugin_client.measure)
     measure_thread.start()
+    # Calls Cancel API after 2 seconds.
+    time.sleep(2)
+
+    measurement_plugin_client.cancel()
+
+    measure_thread.join()
+    captured = capsys.readouterr()
+    assert "Measure call has been cancelled." in captured.out
+
+
+def test___measurement_plugin_client___cancel___cancels_stream_measure_call(
+    measurement_plugin_client_module: ModuleType,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    test_measurement_client_type = getattr(measurement_plugin_client_module, "TestMeasurement")
+    measurement_plugin_client = test_measurement_client_type()
+    measure_thread = threading.Thread(
+        target=lambda: list(map(lambda i: print(i), measurement_plugin_client.stream_measure()))
+    )
+    measure_thread.start()
+    # Calls Cancel API after 2 seconds.
     time.sleep(2)
 
     measurement_plugin_client.cancel()

--- a/packages/generator/tests/test_assets/example_renders/measurement_plugin_client/non_streaming_data_measurement_client.py
+++ b/packages/generator/tests/test_assets/example_renders/measurement_plugin_client/non_streaming_data_measurement_client.py
@@ -1,4 +1,4 @@
-"""Python Measurement Plug-In Client."""
+"""Generated client API for the 'Non-Streaming Data Measurement (Py)' measurement plug-in."""
 
 import logging
 import threading
@@ -29,8 +29,8 @@ _logger = logging.getLogger(__name__)
 _V2_MEASUREMENT_SERVICE_INTERFACE = "ni.measurementlink.measurement.v2.MeasurementService"
 
 
-class Output(NamedTuple):
-    """Measurement result container."""
+class Outputs(NamedTuple):
+    """Outputs for the 'Non-Streaming Data Measurement (Py)' measurement plug-in."""
 
     float_out: float
     double_array_out: List[float]
@@ -46,7 +46,7 @@ class Output(NamedTuple):
 
 
 class NonStreamingDataMeasurementClient:
-    """Client to interact with the measurement plug-in."""
+    """Client for the 'Non-Streaming Data Measurement (Py)' measurement plug-in."""
 
     def __init__(
         self,
@@ -369,7 +369,9 @@ class NonStreamingDataMeasurementClient:
             configuration_parameters=serialized_configuration
         )
 
-    def _deserialize_response(self, response: v2_measurement_service_pb2.MeasureResponse) -> Output:
+    def _deserialize_response(
+        self, response: v2_measurement_service_pb2.MeasureResponse
+    ) -> Outputs:
         if self._output_metadata:
             result = [None] * max(self._output_metadata.keys())
         else:
@@ -380,7 +382,7 @@ class NonStreamingDataMeasurementClient:
 
         for k, v in output_values.items():
             result[k - 1] = v
-        return Output._make(result)
+        return Outputs._make(result)
 
     def measure(
         self,
@@ -394,11 +396,11 @@ class NonStreamingDataMeasurementClient:
         io_in: str = "resource",
         io_array_in: List[str] = ["resource1", "resource2"],
         integer_in: int = 10,
-    ) -> Output:
-        """Executes the Non-Streaming Data Measurement (Py).
+    ) -> Outputs:
+        """Perform a single measurement.
 
         Returns:
-            Measurement output.
+            Measurement outputs.
         """
         stream_measure_response = self.stream_measure(
             float_in,
@@ -428,11 +430,11 @@ class NonStreamingDataMeasurementClient:
         io_in: str = "resource",
         io_array_in: List[str] = ["resource1", "resource2"],
         integer_in: int = 10,
-    ) -> Generator[Output, None, None]:
-        """Executes the Non-Streaming Data Measurement (Py).
+    ) -> Generator[Outputs, None, None]:
+        """Perform a streaming measurement.
 
         Returns:
-            Stream of measurement output.
+            Stream of measurement outputs.
         """
         parameter_values = [
             float_in,

--- a/packages/generator/tests/test_assets/example_renders/measurement_plugin_client/non_streaming_data_measurement_client.py
+++ b/packages/generator/tests/test_assets/example_renders/measurement_plugin_client/non_streaming_data_measurement_client.py
@@ -398,7 +398,7 @@ class NonStreamingDataMeasurementClient:
         Returns:
             Measurement output.
         """
-        parameter_values = [
+        stream_measure_response = self.stream_measure(
             float_in,
             double_array_in,
             bool_in,
@@ -409,19 +409,10 @@ class NonStreamingDataMeasurementClient:
             io_in,
             io_array_in,
             integer_in,
-        ]
-        request = self._create_measure_request(parameter_values)
-        self._measure_response = self._get_stub().Measure(request)
-
-        try:
-            for response in self._measure_response:
-                result = response
-            return self._deserialize_response(result)
-        except grpc.RpcError as e:
-            if e.code() == grpc.StatusCode.CANCELLED:
-                print("Measure call has been cancelled.")
-            else:
-                raise
+        )
+        for response in stream_measure_response:
+            result = response
+        return result
 
     def stream_measure(
         self,

--- a/packages/generator/tests/test_assets/example_renders/measurement_plugin_client/non_streaming_data_measurement_client.py
+++ b/packages/generator/tests/test_assets/example_renders/measurement_plugin_client/non_streaming_data_measurement_client.py
@@ -398,18 +398,22 @@ class NonStreamingDataMeasurementClient:
         Returns:
             Measurement output.
         """
-        stream_measure_response = self.stream_measure(
-            float_in,
-            double_array_in,
-            bool_in,
-            string_in,
-            string_array_in,
-            path_in,
-            path_array_in,
-            io_in,
-            io_array_in,
-            integer_in,
-        )
+        with self._initialization_lock:
+            if self._measure_response is not None:
+                print("A measure call is already in progress.")
+                return
+            stream_measure_response = self.stream_measure(
+                float_in,
+                double_array_in,
+                bool_in,
+                string_in,
+                string_array_in,
+                path_in,
+                path_array_in,
+                io_in,
+                io_array_in,
+                integer_in,
+            )
         for response in stream_measure_response:
             result = response
         return result
@@ -444,18 +448,26 @@ class NonStreamingDataMeasurementClient:
             io_array_in,
             integer_in,
         ]
-        request = self._create_measure_request(parameter_values)
-        self._measure_response = self._get_stub().Measure(request)
-
+        with self._initialization_lock:
+            if self._measure_response is not None:
+                print("A measure call is already in progress.")
+                return
+            request = self._create_measure_request(parameter_values)
+            self._measure_response = self._get_stub().Measure(request)
         try:
             for response in self._measure_response:
                 yield self._deserialize_response(response)
         except grpc.RpcError as e:
             if e.code() == grpc.StatusCode.CANCELLED:
-                print("Measure call has been cancelled.")
+                print("The measure call is canceled.")
             else:
                 raise
+        finally:
+            self._measure_response = None
 
     def cancel(self) -> None:
         if self._measure_response and self._measure_response.is_active():
-            self._measure_response.cancel()
+            with self._initialization_lock:
+                self._measure_response.cancel()
+        else:
+            print("The measure call is not initialized at this moment.")

--- a/packages/generator/tests/test_assets/example_renders/measurement_plugin_client/non_streaming_data_measurement_client.py
+++ b/packages/generator/tests/test_assets/example_renders/measurement_plugin_client/non_streaming_data_measurement_client.py
@@ -64,7 +64,7 @@ class NonStreamingDataMeasurementClient:
 
             grpc_channel_pool: An optional gRPC channel pool.
         """
-        self._initialization_lock = threading.Lock()
+        self._initialization_lock = threading.RLock()
         self._service_class = "ni.tests.NonStreamingDataMeasurement_Python"
         self._grpc_channel_pool = grpc_channel_pool
         self._discovery_client = discovery_client
@@ -450,21 +450,20 @@ class NonStreamingDataMeasurementClient:
                 return
             request = self._create_measure_request(parameter_values)
             self._measure_response = self._get_stub().Measure(request)
+        try:
+            for response in self._measure_response:
+                yield self._deserialize_response(response)
+        except grpc.RpcError as e:
+            if e.code() == grpc.StatusCode.CANCELLED:
+                print("The measure call is canceled.")
+            else:
+                raise
+        finally:
+            self._measure_response = None
 
-            try:
-                for response in self._measure_response:
-                    yield self._deserialize_response(response)
-            except grpc.RpcError as e:
-                if e.code() == grpc.StatusCode.CANCELLED:
-                    print("The measure call is canceled.")
-                else:
-                    raise
-            finally:
-                self._measure_response = None
-
-    def cancel(self) -> None:
+    def cancel(self) -> bool:
         if self._measure_response and self._measure_response.is_active():
-            with self._initialization_lock:
-                self._measure_response.cancel()
+            self._measure_response.cancel()
+            return True
         else:
-            print("The measure call is not initialized at this moment.")
+            return False

--- a/packages/generator/tests/test_assets/example_renders/measurement_plugin_client/non_streaming_data_measurement_client.py
+++ b/packages/generator/tests/test_assets/example_renders/measurement_plugin_client/non_streaming_data_measurement_client.py
@@ -446,8 +446,7 @@ class NonStreamingDataMeasurementClient:
         ]
         with self._initialization_lock:
             if self._measure_response is not None:
-                print("A measure call is already in progress.")
-                return
+                raise RuntimeError("A measure call is already in progress.")
             request = self._create_measure_request(parameter_values)
             self._measure_response = self._get_stub().Measure(request)
         try:

--- a/packages/generator/tests/test_assets/example_renders/measurement_plugin_client/non_streaming_data_measurement_client.py
+++ b/packages/generator/tests/test_assets/example_renders/measurement_plugin_client/non_streaming_data_measurement_client.py
@@ -69,6 +69,7 @@ class NonStreamingDataMeasurementClient:
         self._grpc_channel_pool = grpc_channel_pool
         self._discovery_client = discovery_client
         self._stub: Optional[v2_measurement_service_pb2_grpc.MeasurementServiceStub] = None
+        self._measure_response: Optional[v2_measurement_service_pb2.MeasureResponse] = None
         self._configuration_metadata = {
             1: ParameterMetadata(
                 display_name="Float In",
@@ -410,10 +411,17 @@ class NonStreamingDataMeasurementClient:
             integer_in,
         ]
         request = self._create_measure_request(parameter_values)
+        self._measure_response = self._get_stub().Measure(request)
 
-        for response in self._get_stub().Measure(request):
-            result = self._deserialize_response(response)
-        return result
+        try:
+            for response in self._measure_response:
+                result = self._deserialize_response(response)
+            return result
+        except grpc.RpcError as e:
+            if e.code() == grpc.StatusCode.CANCELLED:
+                print("Measure call has been cancelled.")
+            else:
+                raise
 
     def stream_measure(
         self,
@@ -446,6 +454,17 @@ class NonStreamingDataMeasurementClient:
             integer_in,
         ]
         request = self._create_measure_request(parameter_values)
+        self._measure_response = self._get_stub().Measure(request)
 
-        for response in self._get_stub().Measure(request):
-            yield self._deserialize_response(response)
+        try:
+            for response in self._measure_response:
+                yield self._deserialize_response(response)
+        except grpc.RpcError as e:
+            if e.code() == grpc.StatusCode.CANCELLED:
+                print("Measure call has been cancelled.")
+            else:
+                raise
+
+    def cancel(self) -> None:
+        if self._measure_response and self._measure_response.is_active():
+            self._measure_response.cancel()

--- a/packages/generator/tests/test_assets/example_renders/measurement_plugin_client/non_streaming_data_measurement_client.py
+++ b/packages/generator/tests/test_assets/example_renders/measurement_plugin_client/non_streaming_data_measurement_client.py
@@ -467,7 +467,7 @@ class NonStreamingDataMeasurementClient:
                 self._measure_response = None
 
     def cancel(self) -> bool:
-        """Cancels the active measure call."""
+        """Cancels the active measurement call."""
         with self._initialization_lock:
             if self._measure_response:
                 return self._measure_response.cancel()

--- a/packages/generator/tests/test_assets/example_renders/measurement_plugin_client/non_streaming_data_measurement_client.py
+++ b/packages/generator/tests/test_assets/example_renders/measurement_plugin_client/non_streaming_data_measurement_client.py
@@ -394,7 +394,7 @@ class NonStreamingDataMeasurementClient:
         io_in: str = "resource",
         io_array_in: List[str] = ["resource1", "resource2"],
         integer_in: int = 10,
-    ) -> Optional[Output]:
+    ) -> Output:
         """Executes the Non-Streaming Data Measurement (Py).
 
         Returns:
@@ -412,7 +412,6 @@ class NonStreamingDataMeasurementClient:
             io_array_in,
             integer_in,
         )
-        result = None
         for response in stream_measure_response:
             result = response
         return result
@@ -429,7 +428,7 @@ class NonStreamingDataMeasurementClient:
         io_in: str = "resource",
         io_array_in: List[str] = ["resource1", "resource2"],
         integer_in: int = 10,
-    ) -> Generator[Optional[Output], None, None]:
+    ) -> Generator[Output, None, None]:
         """Executes the Non-Streaming Data Measurement (Py).
 
         Returns:
@@ -449,7 +448,9 @@ class NonStreamingDataMeasurementClient:
         ]
         with self._initialization_lock:
             if self._measure_response is not None:
-                raise RuntimeError("A measure call is already in progress.")
+                raise RuntimeError(
+                    "A measurement is currently in progress. To make concurrent measurement requests, please create a new client instance."
+                )
             request = self._create_measure_request(parameter_values)
             self._measure_response = self._get_stub().Measure(request)
         try:
@@ -457,9 +458,8 @@ class NonStreamingDataMeasurementClient:
                 yield self._deserialize_response(response)
         except grpc.RpcError as e:
             if e.code() == grpc.StatusCode.CANCELLED:
-                _logger.debug("The measure call is canceled.")
-            else:
-                raise
+                _logger.debug("The measurement is canceled.")
+            raise
         finally:
             with self._initialization_lock:
                 self._measure_response = None

--- a/packages/generator/tests/test_assets/example_renders/measurement_plugin_client/non_streaming_data_measurement_client.py
+++ b/packages/generator/tests/test_assets/example_renders/measurement_plugin_client/non_streaming_data_measurement_client.py
@@ -398,22 +398,18 @@ class NonStreamingDataMeasurementClient:
         Returns:
             Measurement output.
         """
-        with self._initialization_lock:
-            if self._measure_response is not None:
-                print("A measure call is already in progress.")
-                return
-            stream_measure_response = self.stream_measure(
-                float_in,
-                double_array_in,
-                bool_in,
-                string_in,
-                string_array_in,
-                path_in,
-                path_array_in,
-                io_in,
-                io_array_in,
-                integer_in,
-            )
+        stream_measure_response = self.stream_measure(
+            float_in,
+            double_array_in,
+            bool_in,
+            string_in,
+            string_array_in,
+            path_in,
+            path_array_in,
+            io_in,
+            io_array_in,
+            integer_in,
+        )
         for response in stream_measure_response:
             result = response
         return result
@@ -454,16 +450,17 @@ class NonStreamingDataMeasurementClient:
                 return
             request = self._create_measure_request(parameter_values)
             self._measure_response = self._get_stub().Measure(request)
-        try:
-            for response in self._measure_response:
-                yield self._deserialize_response(response)
-        except grpc.RpcError as e:
-            if e.code() == grpc.StatusCode.CANCELLED:
-                print("The measure call is canceled.")
-            else:
-                raise
-        finally:
-            self._measure_response = None
+
+            try:
+                for response in self._measure_response:
+                    yield self._deserialize_response(response)
+            except grpc.RpcError as e:
+                if e.code() == grpc.StatusCode.CANCELLED:
+                    print("The measure call is canceled.")
+                else:
+                    raise
+            finally:
+                self._measure_response = None
 
     def cancel(self) -> None:
         if self._measure_response and self._measure_response.is_active():

--- a/packages/generator/tests/test_assets/example_renders/measurement_plugin_client/non_streaming_data_measurement_client.py
+++ b/packages/generator/tests/test_assets/example_renders/measurement_plugin_client/non_streaming_data_measurement_client.py
@@ -415,8 +415,8 @@ class NonStreamingDataMeasurementClient:
 
         try:
             for response in self._measure_response:
-                result = self._deserialize_response(response)
-            return result
+                result = response
+            return self._deserialize_response(result)
         except grpc.RpcError as e:
             if e.code() == grpc.StatusCode.CANCELLED:
                 print("Measure call has been cancelled.")


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Added Cancel API support to Measurement Plug-In Client.
- Added Test cases for Cancel API.

### Why should this Pull Request be merged?

- Cancel API helps user to cancel the measure and stream-measure gRPC calls.

### What testing has been done?

- Tested manually.
- Executed existing and new automated tests.