### PR TITLE
Add multiple client generation

### DIFF
--- a/packages/generator/ni_measurement_plugin_sdk_generator/client/__init__.py
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/client/__init__.py
@@ -99,7 +99,7 @@ def create_client(
         preferred_service_classes = measurement_service_classes.split(",")
 
     for service_class in preferred_service_classes:
-        if can_generate_name(module_name, class_name, all, preferred_service_classes):
+        if can_generate_name(module_name, class_name, preferred_service_classes):
             base_service_class = service_class.split(".")[-1]
             base_service_class = remove_suffix(base_service_class)
             if not base_service_class.isidentifier():
@@ -107,16 +107,14 @@ def create_client(
                     "Unable to create client.\nPlease provide a valid module name or update the measurement with a valid service class."
                 )
 
-            if module_name is None:
+            if module_name is None or len(preferred_service_classes) > 1:
                 module_name = camel_to_snake_case(base_service_class) + "_client"
-            if class_name is None:
+            if class_name is None or len(preferred_service_classes) > 1:
                 class_name = base_service_class.replace("_", "") + "Client"
                 if not any(ch.isupper() for ch in base_service_class):
                     print(
                         f"Warning: The service class '{service_class}' does not follow the recommended format."
                     )
-            if all:
-                print("Module name and class name are generated using the service class.")
 
         if not is_python_identifier(module_name):
             raise click.ClickException(
@@ -133,9 +131,7 @@ def create_client(
         metadata = measurement_service_stub.GetMetadata(
             v2_measurement_service_pb2.GetMetadataRequest()
         )
-        configuration_metadata = get_configuration_metadata_by_index(
-            metadata, service_class
-        )
+        configuration_metadata = get_configuration_metadata_by_index(metadata, service_class)
         output_metadata = get_output_metadata_by_index(metadata)
 
         configuration_parameters_with_type_and_default_values, measure_api_parameters = (

--- a/packages/generator/ni_measurement_plugin_sdk_generator/client/_support.py
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/client/_support.py
@@ -265,10 +265,10 @@ def is_python_identifier(input_string: Optional[str]) -> bool:
 
 
 def can_generate_name(
-    module_name: Optional[str], class_name: Optional[str], all_services: Optional[bool], service_classes: List[str]
+    module_name: Optional[str], class_name: Optional[str], service_classes: List[str]
 ) -> bool:
     """Checks whether to generate a custom name."""
-    return module_name is None or class_name is None or all_services or len(service_classes) > 1
+    return module_name is None or class_name is None or len(service_classes) > 1
 
 
 def _get_python_identifier(input_string: str) -> str:

--- a/packages/generator/tests/acceptance/test_client_generator.py
+++ b/packages/generator/tests/acceptance/test_client_generator.py
@@ -17,7 +17,7 @@ def test___command_line_args___create_client___render_without_error(
     measurement_service: MeasurementService,
 ) -> None:
     temp_directory = tmp_path_factory.mktemp("measurement_plugin_client_files")
-    module_name = "test_measurement_client"
+    module_name = "non_streaming_data_measurement_client"
     golden_path = test_assets_directory / "example_renders" / "measurement_plugin_client"
     filename = f"{module_name}.py"
 
@@ -28,7 +28,32 @@ def test___command_line_args___create_client___render_without_error(
                 "--module-name",
                 module_name,
                 "--class-name",
-                "TestMeasurement",
+                "NonStreamingDataMeasurementClient",
+                "--directory-out",
+                temp_directory,
+            ]
+        )
+
+    assert not exc_info.value.code
+    _assert_equal(
+        golden_path / filename,
+        temp_directory / filename,
+    )
+
+
+def test___command_line_args___create_client_for_all_active_measurement___render_without_error(
+    test_assets_directory: pathlib.Path,
+    tmp_path_factory: pytest.TempPathFactory,
+    measurement_service: MeasurementService,
+) -> None:
+    temp_directory = tmp_path_factory.mktemp("measurement_plugin_client_files")
+    golden_path = test_assets_directory / "example_renders" / "measurement_plugin_client"
+    filename = "non_streaming_data_measurement_client.py"
+
+    with pytest.raises(SystemExit) as exc_info:
+        create_client(
+            [
+                "--all",
                 "--directory-out",
                 temp_directory,
             ]
@@ -46,7 +71,7 @@ def test___command_line_args___create_client___render_with_proper_line_ending(
     measurement_service: MeasurementService,
 ) -> None:
     temp_directory = tmp_path_factory.mktemp("measurement_plugin_client_files")
-    module_name = "test_measurement_client"
+    module_name = "non_streaming_data_measurement_client"
     filename = f"{module_name}.py"
 
     with pytest.raises(SystemExit) as exc_info:
@@ -56,7 +81,7 @@ def test___command_line_args___create_client___render_with_proper_line_ending(
                 "--module-name",
                 module_name,
                 "--class-name",
-                "TestMeasurement",
+                "NonStreamingDataMeasurementClient",
                 "--directory-out",
                 temp_directory,
             ]

--- a/packages/generator/tests/test_assets/example_renders/measurement_plugin_client/non_streaming_data_measurement_client.py
+++ b/packages/generator/tests/test_assets/example_renders/measurement_plugin_client/non_streaming_data_measurement_client.py
@@ -45,7 +45,7 @@ class Output(NamedTuple):
     xy_data_out: DoubleXYData
 
 
-class TestMeasurement:
+class NonStreamingDataMeasurementClient:
     """Client to interact with the measurement plug-in."""
 
     def __init__(


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Add an option to create clients for all active measurement services.
- Allow users to create multiple clients using one-line approach.
- Add automation test for creating client for all active measurement services.

### Why should this Pull Request be merged?

- This implementation allows users to create multiple clients in a single command.

### What testing has been done?

- Tested manually.
- Executed existing and new automated tests.