### PR TITLE
fix: Measurement Plug-In Client Generator Python code injection

### DIFF
--- a/packages/generator/ni_measurement_plugin_sdk_generator/client/__init__.py
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/client/__init__.py
@@ -163,7 +163,7 @@ def create_client(
             file_name=f"{module_name}.py",
             directory_out=directory_out_path,
             class_name=class_name,
-            display_name=repr(metadata.measurement_details.display_name).strip("'").strip('"'),
+            display_name=metadata.measurement_details.display_name,
             configuration_metadata=configuration_metadata,
             output_metadata=output_metadata,
             service_class=service_class,

--- a/packages/generator/ni_measurement_plugin_sdk_generator/client/__init__.py
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/client/__init__.py
@@ -163,7 +163,7 @@ def create_client(
             file_name=f"{module_name}.py",
             directory_out=directory_out_path,
             class_name=class_name,
-            display_name=metadata.measurement_details.display_name,
+            display_name=repr(metadata.measurement_details.display_name).strip("'").strip('"'),
             configuration_metadata=configuration_metadata,
             output_metadata=output_metadata,
             service_class=service_class,

--- a/packages/generator/ni_measurement_plugin_sdk_generator/client/templates/measurement_plugin_client.py.mako
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/client/templates/measurement_plugin_client.py.mako
@@ -43,7 +43,7 @@ class Output(NamedTuple):
 % endif
 
 
-class ${class_name}:
+class ${repr(class_name)}:
     """Client to interact with the measurement plug-in."""
      
     def __init__(
@@ -63,7 +63,7 @@ class ${class_name}:
             grpc_channel_pool: An optional gRPC channel pool.
         """
         self._initialization_lock = threading.Lock()
-        self._service_class = "${service_class}"
+        self._service_class = ${repr(service_class)}
         self._grpc_channel_pool = grpc_channel_pool
         self._discovery_client = discovery_client
         self._stub: Optional[v2_measurement_service_pb2_grpc.MeasurementServiceStub] = None
@@ -161,7 +161,7 @@ class ${class_name}:
         self,
         ${configuration_parameters_with_type_and_default_values}
     ) -> ${output_type} :
-        """Executes the ${display_name}.
+        """Executes the ${repr(display_name)}.
 
         Returns:
             Measurement output.

--- a/packages/generator/ni_measurement_plugin_sdk_generator/client/templates/measurement_plugin_client.py.mako
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/client/templates/measurement_plugin_client.py.mako
@@ -1,6 +1,6 @@
 <%page args="class_name, display_name, configuration_metadata, output_metadata, service_class, configuration_parameters_with_type_and_default_values, measure_api_parameters, output_parameters_with_type, built_in_import_modules, custom_import_modules"/>\
 \
-"""Python Measurement Plug-In Client."""
+"""Generated client API for the ${display_name | repr} measurement plug-in."""
 
 import logging
 import threading
@@ -35,16 +35,16 @@ _V2_MEASUREMENT_SERVICE_INTERFACE = "ni.measurementlink.measurement.v2.Measureme
 <% output_type = "None" %>\
 % if output_metadata:
 
-class Output(NamedTuple):
-    """Measurement result container."""
+class Outputs(NamedTuple):
+    """Outputs for the ${display_name | repr} measurement plug-in."""
 
     ${output_parameters_with_type}
-<% output_type = "Output" %>\
+<% output_type = "Outputs" %>\
 % endif
 
 
 class ${class_name}:
-    """Client to interact with the measurement plug-in."""
+    """Client for the ${display_name | repr} measurement plug-in."""
      
     def __init__(
         self,
@@ -63,7 +63,7 @@ class ${class_name}:
             grpc_channel_pool: An optional gRPC channel pool.
         """
         self._initialization_lock = threading.Lock()
-        self._service_class = "${service_class}"
+        self._service_class = ${service_class | repr}
         self._grpc_channel_pool = grpc_channel_pool
         self._discovery_client = discovery_client
         self._stub: Optional[v2_measurement_service_pb2_grpc.MeasurementServiceStub] = None
@@ -144,7 +144,7 @@ class ${class_name}:
 
     def _deserialize_response(
         self, response: v2_measurement_service_pb2.MeasureResponse
-    ) -> Output:
+    ) -> Outputs:
         if self._output_metadata:
             result = [None] * max(self._output_metadata.keys())
         else:
@@ -155,16 +155,16 @@ class ${class_name}:
 
         for k, v in output_values.items():
             result[k - 1] = v
-        return Output._make(result)
+        return Outputs._make(result)
 
     def measure(
         self,
         ${configuration_parameters_with_type_and_default_values}
     ) -> ${output_type} :
-        """Executes the ${display_name}.
+        """Perform a single measurement.
 
         Returns:
-            Measurement output.
+            Measurement outputs.
         """
         parameter_values = [${measure_api_parameters}]
         request = self._create_measure_request(parameter_values)
@@ -177,10 +177,10 @@ class ${class_name}:
         self,
         ${configuration_parameters_with_type_and_default_values}
     ) -> Generator[${output_type}, None, None] :
-        """Executes the ${display_name}.
+        """Perform a streaming measurement.
 
         Returns:
-            Stream of measurement output.
+            Stream of measurement outputs.
         """
         parameter_values = [${measure_api_parameters}]
         request = self._create_measure_request(parameter_values)

--- a/packages/generator/ni_measurement_plugin_sdk_generator/client/templates/measurement_plugin_client.py.mako
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/client/templates/measurement_plugin_client.py.mako
@@ -43,7 +43,7 @@ class Output(NamedTuple):
 % endif
 
 
-class ${repr(class_name)}:
+class ${class_name}:
     """Client to interact with the measurement plug-in."""
      
     def __init__(
@@ -63,7 +63,7 @@ class ${repr(class_name)}:
             grpc_channel_pool: An optional gRPC channel pool.
         """
         self._initialization_lock = threading.Lock()
-        self._service_class = ${repr(service_class)}
+        self._service_class = "${service_class}"
         self._grpc_channel_pool = grpc_channel_pool
         self._discovery_client = discovery_client
         self._stub: Optional[v2_measurement_service_pb2_grpc.MeasurementServiceStub] = None
@@ -161,7 +161,7 @@ class ${repr(class_name)}:
         self,
         ${configuration_parameters_with_type_and_default_values}
     ) -> ${output_type} :
-        """Executes the ${repr(display_name)}.
+        """Executes the ${display_name}.
 
         Returns:
             Measurement output.


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Add `repr()` function to the string parameters in the `mako template` to omit arbitrary Python code in the output.

### Why should this Pull Request be merged?

[Bug 2843797](https://dev.azure.com/ni/DevCentral/_workitems/edit/2843797)
- If any malicious service returns metadata with escape sequences, that results in arbitrary Python code injection in the output. This implementation handles the escape sequences with `repr()`.

### What testing has been done?

- Tested manually.