### PR TITLE
Update default channel pool options when creating grpc channels

### DIFF
--- a/packages/service/tests/unit/grpc/__init__.py
+++ b/packages/service/tests/unit/grpc/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for ni_measurement_plugin_sdk_service.grpc."""

--- a/packages/service/tests/unit/grpc/channelpool/__init__.py
+++ b/packages/service/tests/unit/grpc/channelpool/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for ni_measurement_plugin_sdk_service.grpc.channelpool."""

--- a/packages/service/tests/unit/grpc/channelpool/test_channel_pool.py
+++ b/packages/service/tests/unit/grpc/channelpool/test_channel_pool.py
@@ -1,0 +1,32 @@
+import pytest
+
+from ni_measurement_plugin_sdk_service.grpc.channelpool import GrpcChannelPool
+
+
+@pytest.mark.parametrize(
+    "target,expected_result",
+    [
+        ("127.0.0.1", False),
+        ("[::1]", False),
+        ("localhost", False),
+        ("127.0.0.1:100", True),
+        ("[::1]:100", True),
+        ("localhost:100", True),
+        ("http://127.0.0.1", False),
+        ("http://[::1]", False),
+        ("http://localhost", False),
+        ("http://127.0.0.1:100", True),
+        ("http://[::1]:100", True),
+        ("http://localhost:100", True),
+        ("1.1.1.1:100", False),
+        ("http://www.google.com:80", False),
+    ],
+)
+def test___channel_pool___is_local___returns_expected_result(
+    target: str, expected_result: bool
+) -> None:
+    channel_pool = GrpcChannelPool()
+
+    result = channel_pool._is_local(target)
+
+    assert result == expected_result


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Updates the channel pool so that by default it:
- Does not limit the size of messages that can be sent across a channel.
- Disables http proxy if it determines the target address is for the localhost. DNS lookups are not performed as part of this calculation for simplicity and performance for what is expected to be the most common scenarios.

### Why should this Pull Request be merged?

This minimizes support issues with http proxies that are often difficult to diagnose.

### What testing has been done?

- Added unit tests for logic which determines whether an address string is for the localhost or not. 
- I manually tested with the `http_proxy` environment variable set before and after this change. I validated that example measurements fail to start successfully before the change (can't connect to discovery when trying to register themselves), and they start successfully after this change.