### PR TITLE
Update measurement client generator to interact with C# measurement services

### DIFF
--- a/packages/generator/ni_measurement_plugin_sdk_generator/client/__init__.py
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/client/__init__.py
@@ -88,6 +88,7 @@ def create_client(
     discovery_client = DiscoveryClient(grpc_channel_pool=channel_pool)
     built_in_import_modules: List[str] = []
     custom_import_modules: List[str] = []
+    type_url_prefix = "type.googleapis.com/"
 
     if all:
         measurement_service_class = get_all_registered_measurement_service_classes(discovery_client)
@@ -172,7 +173,7 @@ def create_client(
             output_parameters_with_type=output_parameters_with_type,
             built_in_import_modules=to_ordered_set(built_in_import_modules),
             custom_import_modules=to_ordered_set(custom_import_modules),
-            type_url=f"type.googleapis.com/{metadata.measurement_signature.configuration_parameters_message_type}",
+            type_url=type_url_prefix + metadata.measurement_signature.configuration_parameters_message_type,
         )
 
         print(

--- a/packages/generator/ni_measurement_plugin_sdk_generator/client/__init__.py
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/client/__init__.py
@@ -172,6 +172,7 @@ def create_client(
             output_parameters_with_type=output_parameters_with_type,
             built_in_import_modules=to_ordered_set(built_in_import_modules),
             custom_import_modules=to_ordered_set(custom_import_modules),
+            type_url=f"type.googleapis.com/{metadata.measurement_signature.configuration_parameters_message_type}",
         )
 
         print(

--- a/packages/generator/ni_measurement_plugin_sdk_generator/client/templates/measurement_plugin_client.py.mako
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/client/templates/measurement_plugin_client.py.mako
@@ -1,4 +1,4 @@
-<%page args="class_name, display_name, configuration_metadata, output_metadata, service_class, configuration_parameters_with_type_and_default_values, measure_api_parameters, output_parameters_with_type, built_in_import_modules, custom_import_modules"/>\
+<%page args="class_name, display_name, configuration_metadata, output_metadata, service_class, configuration_parameters_with_type_and_default_values, measure_api_parameters, output_parameters_with_type, built_in_import_modules, custom_import_modules, type_url"/>\
 \
 """Generated client API for the ${display_name | repr} measurement plug-in."""
 
@@ -188,6 +188,7 @@ class ${class_name}:
         self, parameter_values: List[Any]
     ) -> v2_measurement_service_pb2.MeasureRequest:
         serialized_configuration = any_pb2.Any(
+            type_url=${type_url | repr},
             value=serialize_parameters(
                 parameter_metadata_dict=self._configuration_metadata,
                 parameter_values=parameter_values,

--- a/packages/generator/tests/test_assets/example_renders/measurement_plugin_client/non_streaming_data_measurement_client.py
+++ b/packages/generator/tests/test_assets/example_renders/measurement_plugin_client/non_streaming_data_measurement_client.py
@@ -414,11 +414,12 @@ class NonStreamingDataMeasurementClient:
         self, parameter_values: List[Any]
     ) -> v2_measurement_service_pb2.MeasureRequest:
         serialized_configuration = any_pb2.Any(
+            type_url="type.googleapis.com/ni.measurementlink.measurement.v2.MeasurementConfigurations",
             value=serialize_parameters(
                 parameter_metadata_dict=self._configuration_metadata,
                 parameter_values=parameter_values,
                 service_name=f"{self._service_class}.Configurations",
-            )
+            ),
         )
         return v2_measurement_service_pb2.MeasureRequest(
             configuration_parameters=serialized_configuration,


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Add `type_url` to `MeasureRequest.configuration_parameters`, while creating measure request, as the C# measurement services validates `type_url`. 

### Why should this Pull Request be merged?

- As, the C# measurement services validates `type_url`, the generated measurement client throws error while calling measure API  ([Bug #851](https://github.com/ni/measurement-plugin-python/issues/851)). 
- This implementation contains the fix to make generated measurement client to interact with C# measurement.

### What testing has been done?

- Existing automated test cases passed.
- Done manual testing.