### PR TITLE
Fix build of NIMS by including a working-directory

### DIFF
--- a/.github/workflows/Publish_NIMS.yml
+++ b/.github/workflows/Publish_NIMS.yml
@@ -86,6 +86,7 @@ jobs:
         if: ${{ startsWith(github.event.release.target_commitish, 'main') || startsWith(github.event.release.target_commitish, 'releases/') }}
         run: |
           poetry publish --build --username __token__ --password ${{ secrets.PYPI_TOKEN }}
+        working-directory: ./packages/service
         
       - name: Build NIMG Python package and publish to PyPI
         if: ${{ startsWith(github.event.release.target_commitish, 'main') || startsWith(github.event.release.target_commitish, 'releases/') }}


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Fix a build failure when building NIMS. pyproject.toml has moved under packages/service
https://github.com/ni/measurement-plugin-python/actions/runs/10910761526/job/30281908129


### Why should this Pull Request be merged?

Fix build and publish.

### What testing has been done?

None