### PR TITLE
Add test case for measurements with no output configuration in client generation acceptance test

### DIFF
--- a/packages/generator/ni_measurement_plugin_sdk_generator/client/templates/measurement_plugin_client.py.mako
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/client/templates/measurement_plugin_client.py.mako
@@ -8,7 +8,12 @@ import threading
 from enum import Enum
 % endif
 from pathlib import Path
-from typing import Any, Generator${", Iterable" if output_metadata else ""}, List${", NamedTuple" if output_metadata else ""}, Optional
+<%
+    typing_imports = ["Any", "Generator", "List", "Optional"]
+    if output_metadata:
+        typing_imports += ["Iterable", "NamedTuple"]
+%>\
+from typing import ${", ".join(sorted(typing_imports))}
 
 import grpc
 from google.protobuf import any_pb2, descriptor_pool

--- a/packages/generator/tests/acceptance/test_client_generator.py
+++ b/packages/generator/tests/acceptance/test_client_generator.py
@@ -67,7 +67,7 @@ def test___command_line_args_for_void_measurement___create_client___render_witho
             "--class-name",
             "VoidMeasurementClient",
             "--directory-out",
-            temp_directory,
+            str(temp_directory),
         ]
     )
 

--- a/packages/generator/tests/acceptance/test_client_generator.py
+++ b/packages/generator/tests/acceptance/test_client_generator.py
@@ -9,14 +9,18 @@ from ni_measurement_plugin_sdk_service.measurement.service import MeasurementSer
 
 from tests.conftest import CliRunnerFunction
 from tests.utilities.discovery_service_process import DiscoveryServiceProcess
-from tests.utilities.measurements import non_streaming_data_measurement, streaming_data_measurement
+from tests.utilities.measurements import (
+    non_streaming_data_measurement,
+    streaming_data_measurement,
+    void_measurement,
+)
 
 
-def test___command_line_args___create_client___render_without_error(
+def test___command_line_args_for_non_streaming_measurement___create_client___render_without_error(
     create_client: CliRunnerFunction,
     test_assets_directory: pathlib.Path,
     tmp_path_factory: pytest.TempPathFactory,
-    measurement_service: MeasurementService,
+    non_streaming_measurement_service: MeasurementService,
 ) -> None:
     temp_directory = tmp_path_factory.mktemp("measurement_plugin_client_files")
     module_name = "non_streaming_data_measurement_client"
@@ -43,7 +47,38 @@ def test___command_line_args___create_client___render_without_error(
     )
 
 
-def test___command_line_args___create_client_for_all_registered_measurements___renders_without_error(
+def test___command_line_args_for_void_measurement___create_client___render_without_error(
+    create_client: CliRunnerFunction,
+    test_assets_directory: pathlib.Path,
+    tmp_path_factory: pytest.TempPathFactory,
+    void_measurement_service: MeasurementService,
+) -> None:
+    temp_directory = tmp_path_factory.mktemp("measurement_plugin_client_files")
+    module_name = "void_measurement_client"
+    golden_path = test_assets_directory / "example_renders" / "measurement_plugin_client"
+    filename = f"{module_name}.py"
+
+    result = create_client(
+        [
+            "--measurement-service-class",
+            "ni.tests.VoidMeasurement_Python",
+            "--module-name",
+            module_name,
+            "--class-name",
+            "VoidMeasurementClient",
+            "--directory-out",
+            temp_directory,
+        ]
+    )
+
+    assert result.exit_code == 0
+    _assert_equal(
+        golden_path / filename,
+        temp_directory / filename,
+    )
+
+
+def test___command_line_args_for_all_registered_measurements___create_client___renders_without_error(
     create_client: CliRunnerFunction,
     tmp_path_factory: pytest.TempPathFactory,
     multiple_measurement_service: MeasurementService,
@@ -76,7 +111,7 @@ def test___command_line_args_with_registered_measurements___create_client_using_
     create_client: CliRunnerFunction,
     test_assets_directory: pathlib.Path,
     tmp_path_factory: pytest.TempPathFactory,
-    measurement_service: MeasurementService,
+    non_streaming_measurement_service: MeasurementService,
 ) -> None:
     temp_directory = tmp_path_factory.mktemp("measurement_plugin_client_files")
     golden_path = test_assets_directory / "example_renders" / "measurement_plugin_client"
@@ -109,7 +144,7 @@ def test___command_line_args_without_registering_any_measurement___create_client
 def test___command_line_args___create_client___render_with_proper_line_ending(
     create_client: CliRunnerFunction,
     tmp_path_factory: pytest.TempPathFactory,
-    measurement_service: MeasurementService,
+    non_streaming_measurement_service: MeasurementService,
 ) -> None:
     temp_directory = tmp_path_factory.mktemp("measurement_plugin_client_files")
     module_name = "non_streaming_data_measurement_client"
@@ -154,11 +189,20 @@ def _assert_line_ending(file_path: pathlib.Path) -> None:
 
 
 @pytest.fixture
-def measurement_service(
+def non_streaming_measurement_service(
     discovery_service_process: DiscoveryServiceProcess,
 ) -> Generator[MeasurementService, None, None]:
-    """Test fixture that creates and hosts a Measurement Plug-In Service."""
+    """Test fixture that creates and hosts a non streaming Measurement Plug-In Service."""
     with non_streaming_data_measurement.measurement_service.host_service() as service:
+        yield service
+
+
+@pytest.fixture
+def void_measurement_service(
+    discovery_service_process: DiscoveryServiceProcess,
+) -> Generator[MeasurementService, None, None]:
+    """Test fixture that creates and hosts a void Measurement Plug-In Service."""
+    with void_measurement.measurement_service.host_service() as service:
         yield service
 
 

--- a/packages/generator/tests/acceptance/test_client_generator.py
+++ b/packages/generator/tests/acceptance/test_client_generator.py
@@ -16,7 +16,7 @@ from tests.utilities.measurements import (
 )
 
 
-def test___command_line_args_for_non_streaming_measurement___create_client___render_without_error(
+def test___non_streaming_measurement___create_client___render_without_error(
     create_client: CliRunnerFunction,
     test_assets_directory: pathlib.Path,
     tmp_path_factory: pytest.TempPathFactory,
@@ -47,7 +47,7 @@ def test___command_line_args_for_non_streaming_measurement___create_client___ren
     )
 
 
-def test___command_line_args_for_void_measurement___create_client___render_without_error(
+def test___void_measurement___create_client___render_without_error(
     create_client: CliRunnerFunction,
     test_assets_directory: pathlib.Path,
     tmp_path_factory: pytest.TempPathFactory,
@@ -78,7 +78,7 @@ def test___command_line_args_for_void_measurement___create_client___render_witho
     )
 
 
-def test___command_line_args_for_all_registered_measurements___create_client___renders_without_error(
+def test___all_registered_measurements___create_client___renders_without_error(
     create_client: CliRunnerFunction,
     tmp_path_factory: pytest.TempPathFactory,
     multiple_measurement_service: MeasurementService,
@@ -107,7 +107,7 @@ def test___command_line_args_for_all_registered_measurements___create_client___r
     )
 
 
-def test___command_line_args_with_registered_measurements___create_client_using_interactive_mode___renders_without_error(
+def test___interactive_mode_with_registered_measurements___create_client___renders_without_error(
     create_client: CliRunnerFunction,
     test_assets_directory: pathlib.Path,
     tmp_path_factory: pytest.TempPathFactory,
@@ -133,7 +133,7 @@ def test___command_line_args_with_registered_measurements___create_client_using_
     )
 
 
-def test___command_line_args_without_registering_any_measurement___create_client_using_interactive_mode___raises_exception(
+def test___interactive_mode_without_registered_measurements___create_client___raises_exception(
     create_client: CliRunnerFunction,
 ) -> None:
     result = create_client(["--interactive"])
@@ -141,7 +141,7 @@ def test___command_line_args_without_registering_any_measurement___create_client
     assert "No registered measurements." in str(result.exception)
 
 
-def test___command_line_args___create_client___render_with_proper_line_ending(
+def test___non_streaming_measurement___create_client___render_with_proper_line_ending(
     create_client: CliRunnerFunction,
     tmp_path_factory: pytest.TempPathFactory,
     non_streaming_measurement_service: MeasurementService,

--- a/packages/generator/tests/test_assets/example_renders/measurement_plugin_client/non_streaming_data_measurement_client.py
+++ b/packages/generator/tests/test_assets/example_renders/measurement_plugin_client/non_streaming_data_measurement_client.py
@@ -1,15 +1,13 @@
 """Generated client API for the 'Non-Streaming Data Measurement (Py)' measurement plug-in."""
 
 import logging
-import pathlib
 import threading
 from enum import Enum
 from pathlib import Path
 from typing import Any, Generator, Iterable, List, NamedTuple, Optional
 
 import grpc
-from google.protobuf import any_pb2
-from google.protobuf import descriptor_pool
+from google.protobuf import any_pb2, descriptor_pool
 from ni_measurement_plugin_sdk_service._internal.stubs.ni.measurementlink.measurement.v2 import (
     measurement_service_pb2 as v2_measurement_service_pb2,
     measurement_service_pb2_grpc as v2_measurement_service_pb2_grpc,
@@ -621,7 +619,7 @@ class NonStreamingDataMeasurementClient:
             else:
                 return False
 
-    def register_pin_map(self, pin_map_path: pathlib.Path) -> None:
+    def register_pin_map(self, pin_map_path: Path) -> None:
         """Registers the pin map with the pin map service.
 
         Args:

--- a/packages/generator/tests/test_assets/example_renders/measurement_plugin_client/void_measurement_client.py
+++ b/packages/generator/tests/test_assets/example_renders/measurement_plugin_client/void_measurement_client.py
@@ -1,14 +1,9 @@
-<%page args="class_name, display_name, configuration_metadata, output_metadata, service_class, configuration_parameters_with_type_and_default_values, measure_api_parameters, output_parameters_with_type, built_in_import_modules, custom_import_modules, enum_by_class_name"/>\
-\
-"""Generated client API for the ${display_name | repr} measurement plug-in."""
+"""Generated client API for the 'Void Measurement (Py)' measurement plug-in."""
 
 import logging
 import threading
-% if len(enum_by_class_name):
-from enum import Enum
-% endif
 from pathlib import Path
-from typing import Any, Generator${", Iterable" if output_metadata else ""}, List${", NamedTuple" if output_metadata else ""}, Optional
+from typing import Any, Generator, List, Optional
 
 import grpc
 from google.protobuf import any_pb2, descriptor_pool
@@ -16,16 +11,10 @@ from ni_measurement_plugin_sdk_service._internal.stubs.ni.measurementlink.measur
     measurement_service_pb2 as v2_measurement_service_pb2,
     measurement_service_pb2_grpc as v2_measurement_service_pb2_grpc,
 )
-% for module in custom_import_modules:
-${module}
-% endfor
 from ni_measurement_plugin_sdk_service.discovery import DiscoveryClient
 from ni_measurement_plugin_sdk_service.grpc.channelpool import GrpcChannelPool
 from ni_measurement_plugin_sdk_service.measurement.client_support import (
     create_file_descriptor,
-% if output_metadata:
-    deserialize_parameters,
-% endif
     ParameterMetadata,
     serialize_parameters,
 )
@@ -36,30 +25,10 @@ _logger = logging.getLogger(__name__)
 
 _V2_MEASUREMENT_SERVICE_INTERFACE = "ni.measurementlink.measurement.v2.MeasurementService"
 
-% for enum_name, enum_value in enum_by_class_name.items():
 
-class ${enum_name.__name__}(Enum):
-    """${enum_name.__name__} used for enum-typed measurement configs and outputs."""
+class VoidMeasurementClient:
+    """Client for the 'Void Measurement (Py)' measurement plug-in."""
 
-    % for key, val in enum_value.items():
-    ${key} = ${val}
-    % endfor
-% endfor
-
-<% output_type = "None" %>\
-% if output_metadata:
-
-class Outputs(NamedTuple):
-    """Outputs for the ${display_name | repr} measurement plug-in."""
-
-    ${output_parameters_with_type}
-<% output_type = "Outputs" %>\
-% endif
-
-
-class ${class_name}:
-    """Client for the ${display_name | repr} measurement plug-in."""
-     
     def __init__(
         self,
         *,
@@ -80,7 +49,7 @@ class ${class_name}:
             grpc_channel_pool: An optional gRPC channel pool.
         """
         self._initialization_lock = threading.RLock()
-        self._service_class = ${service_class | repr}
+        self._service_class = "ni.tests.VoidMeasurement_Python"
         self._grpc_channel_pool = grpc_channel_pool
         self._discovery_client = discovery_client
         self._pin_map_client = pin_map_client
@@ -88,8 +57,19 @@ class ${class_name}:
         self._measure_response: Optional[
             Generator[v2_measurement_service_pb2.MeasureResponse, None, None]
         ] = None
-        self._configuration_metadata = ${configuration_metadata}
-        self._output_metadata = ${output_metadata}
+        self._configuration_metadata = {
+            1: ParameterMetadata(
+                display_name="Integer In",
+                type=5,
+                repeated=False,
+                default_value=10,
+                annotations={},
+                message_type="",
+                field_name="Integer_In",
+                enum_type=None,
+            )
+        }
+        self._output_metadata = {}
         if grpc_channel is not None:
             self._stub = v2_measurement_service_pb2_grpc.MeasurementServiceStub(grpc_channel)
         self._create_file_descriptor()
@@ -130,7 +110,9 @@ class ${class_name}:
                         provided_interface=_V2_MEASUREMENT_SERVICE_INTERFACE,
                         service_class=self._service_class,
                     )
-                    channel = self._get_grpc_channel_pool().get_channel(service_location.insecure_address)
+                    channel = self._get_grpc_channel_pool().get_channel(
+                        service_location.insecure_address
+                    )
                     self._stub = v2_measurement_service_pb2_grpc.MeasurementServiceStub(channel)
         return self._stub
 
@@ -155,7 +137,7 @@ class ${class_name}:
             with self._initialization_lock:
                 if self._pin_map_client is None:
                     self._pin_map_client = PinMapClient(
-                        discovery_client=self._get_discovery_client(), 
+                        discovery_client=self._get_discovery_client(),
                         grpc_channel_pool=self._get_grpc_channel_pool(),
                     )
         return self._pin_map_client
@@ -183,57 +165,23 @@ class ${class_name}:
             pin_map_context=self._pin_map_context._to_grpc() if self._pin_map_context else None,
         )
 
-    % if output_metadata:
-    def _deserialize_response(
-        self, response: v2_measurement_service_pb2.MeasureResponse
-    ) -> Outputs:
-        if self._output_metadata:
-            result = [None] * max(self._output_metadata.keys())
-        else:
-            result = []
-        output_values = deserialize_parameters(
-            self._output_metadata, response.outputs.value, f"{self._service_class}.Outputs"
-        )
-
-        for k, v in output_values.items():
-            result[k - 1] = v
-        return Outputs._make(result)
-    % endif
-
-    def measure(
-        self,
-        ${configuration_parameters_with_type_and_default_values}
-    ) -> ${output_type} :
+    def measure(self, integer_in: int = 10) -> None:
         """Perform a single measurement.
 
         Returns:
             Measurement outputs.
         """
-        stream_measure_response = self.stream_measure(
-            ${measure_api_parameters}
-        )
+        stream_measure_response = self.stream_measure(integer_in)
         for response in stream_measure_response:
-        % if output_metadata:
-            result = response
-        return result
-        % else:
             pass
-        % endif
 
-    def stream_measure(
-        self,
-        ${configuration_parameters_with_type_and_default_values}
-    ) -> Generator[${output_type}, None, None] :
+    def stream_measure(self, integer_in: int = 10) -> Generator[None, None, None]:
         """Perform a streaming measurement.
 
         Returns:
             Stream of measurement outputs.
         """
-        % if "from pathlib import Path" in built_in_import_modules:
-        parameter_values = _convert_paths_to_strings([${measure_api_parameters}])
-        % else:
-        parameter_values = [${measure_api_parameters}]
-        % endif
+        parameter_values = [integer_in]
         with self._initialization_lock:
             if self._measure_response is not None:
                 raise RuntimeError(
@@ -241,14 +189,9 @@ class ${class_name}:
                 )
             request = self._create_measure_request(parameter_values)
             self._measure_response = self._get_stub().Measure(request)
-
         try:
             for response in self._measure_response:
-                % if output_metadata:
-                yield self._deserialize_response(response)
-                % else:
                 yield
-                % endif
         except grpc.RpcError as e:
             if e.code() == grpc.StatusCode.CANCELLED:
                 _logger.debug("The measurement is canceled.")
@@ -276,25 +219,3 @@ class ${class_name}:
             self._pin_map_context = PinMapContext(pin_map_id=pin_map_id, sites=[0])
         else:
             self._pin_map_context = self._pin_map_context._replace(pin_map_id=pin_map_id)
-
-% if "from pathlib import Path" in built_in_import_modules:
-
-def _convert_paths_to_strings(parameter_values: Iterable[Any]) -> List[Any]:
-    result: List[Any] = []
-
-    for parameter_value in parameter_values:
-        if isinstance(parameter_value, list):
-            converted_list = []
-            for value in parameter_value:
-                if isinstance(value, Path):
-                    converted_list.append(str(value))
-                else:
-                    converted_list.append(value)
-            result.append(converted_list)
-        elif isinstance(parameter_value, Path):
-            result.append(str(parameter_value))
-        else:
-            result.append(parameter_value)
-    return result
-
-% endif

--- a/packages/generator/tests/test_assets/example_renders/measurement_plugin_client/void_measurement_client.py
+++ b/packages/generator/tests/test_assets/example_renders/measurement_plugin_client/void_measurement_client.py
@@ -154,11 +154,12 @@ class VoidMeasurementClient:
         self, parameter_values: List[Any]
     ) -> v2_measurement_service_pb2.MeasureRequest:
         serialized_configuration = any_pb2.Any(
+            type_url="type.googleapis.com/ni.measurementlink.measurement.v2.MeasurementConfigurations",
             value=serialize_parameters(
                 parameter_metadata_dict=self._configuration_metadata,
                 parameter_values=parameter_values,
                 service_name=f"{self._service_class}.Configurations",
-            )
+            ),
         )
         return v2_measurement_service_pb2.MeasureRequest(
             configuration_parameters=serialized_configuration,

--- a/packages/generator/tests/utilities/measurements/void_measurement/VoidMeasurement.serviceconfig
+++ b/packages/generator/tests/utilities/measurements/void_measurement/VoidMeasurement.serviceconfig
@@ -14,7 +14,6 @@
         "ni/service.collection": "NI.Tests",
         "ni/service.tags": []
       }
-
     }
   ]
 }

--- a/packages/generator/tests/utilities/measurements/void_measurement/VoidMeasurement.serviceconfig
+++ b/packages/generator/tests/utilities/measurements/void_measurement/VoidMeasurement.serviceconfig
@@ -1,0 +1,20 @@
+{
+  "services": [
+    {
+      "displayName": "Void Measurement (Py)",
+      "serviceClass": "ni.tests.VoidMeasurement_Python",
+      "descriptionUrl": "",
+      "providedInterfaces": [
+        "ni.measurementlink.measurement.v1.MeasurementService",
+        "ni.measurementlink.measurement.v2.MeasurementService"
+      ],
+      "path": "start.bat",
+      "annotations": {
+        "ni/service.description": "Measurement plug-in test service that performs a measurement without output.",
+        "ni/service.collection": "NI.Tests",
+        "ni/service.tags": []
+      }
+
+    }
+  ]
+}

--- a/packages/generator/tests/utilities/measurements/void_measurement/__init__.py
+++ b/packages/generator/tests/utilities/measurements/void_measurement/__init__.py
@@ -8,7 +8,6 @@ from typing import List, Tuple
 import grpc
 import ni_measurement_plugin_sdk_service as nims
 
-
 service_directory = Path(__file__).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "VoidMeasurement.serviceconfig",
@@ -33,7 +32,7 @@ def measure(
 
     for index in range(0, integer_input):
         update_time = time.monotonic()
-        data.extend(index)
+        data.append(index)
 
         # Delay for the remaining portion of the requested interval and check for cancellation.
         delay = max(0.0, response_interval_in_seconds - (time.monotonic() - update_time))
@@ -41,3 +40,5 @@ def measure(
             measurement_service.context.abort(
                 grpc.StatusCode.CANCELLED, "Client requested cancellation."
             )
+
+    return ()

--- a/packages/generator/tests/utilities/measurements/void_measurement/__init__.py
+++ b/packages/generator/tests/utilities/measurements/void_measurement/__init__.py
@@ -1,0 +1,43 @@
+"""Contains utility functions to test void measurement service. """
+
+import threading
+import time
+from pathlib import Path
+from typing import List, Tuple
+
+import grpc
+import ni_measurement_plugin_sdk_service as nims
+
+
+service_directory = Path(__file__).resolve().parent
+measurement_service = nims.MeasurementService(
+    service_config_path=service_directory / "VoidMeasurement.serviceconfig",
+    version="0.1.0.0",
+    ui_file_paths=[
+        service_directory,
+    ],
+)
+
+
+@measurement_service.register_measurement
+@measurement_service.configuration("Integer In", nims.DataType.Int32, 10)
+def measure(
+    integer_input: int,
+) -> Tuple[()]:
+    """Perform a measurement with no output."""
+    cancellation_event = threading.Event()
+    measurement_service.context.add_cancel_callback(cancellation_event.set)
+
+    response_interval_in_seconds = 1
+    data: List[int] = []
+
+    for index in range(0, integer_input):
+        update_time = time.monotonic()
+        data.extend(index)
+
+        # Delay for the remaining portion of the requested interval and check for cancellation.
+        delay = max(0.0, response_interval_in_seconds - (time.monotonic() - update_time))
+        if cancellation_event.wait(delay):
+            measurement_service.context.abort(
+                grpc.StatusCode.CANCELLED, "Client requested cancellation."
+            )


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Added a measurement with no output configurations to test utilities.
- Added a test case for measurements with no output configuration in `test_client_generator.py`.
- Added a if condition in `mako`, to remove missing imports during the generation of measurements with no output configuration.
- Remove duplicate imports in `mako`.

### Why should this Pull Request be merged?

- Added a new test case to verify the client generation for the measurements with no output configuration.
- Handle unused imports in `mako`. As, some imports are unused in the client module for the measurements with no output configuration.
- Remove duplicate imports i.e., Path is imported twice, as `pathlib` is already added in `mako`, also, we are adding `pathlib`, during client creation of measurement with path configurations.

### What testing has been done?

- Existing and new automation tests passed.