### PR TITLE
[Minor] Raise exception during Client creation with Double XY datatype as input configuration

### DIFF
--- a/packages/generator/ni_measurement_plugin_sdk_generator/client/_support.py
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/client/_support.py
@@ -226,7 +226,7 @@ def get_configuration_parameters_with_type_and_default_values(
 
         if metadata.message_type and metadata.message_type == "ni.protobuf.types.DoubleXYData":
             raise click.ClickException(
-                "Measurement configuration(s) with Double XY datatype is not supported."
+                "Measurement configuration with Double XY datatype is not supported."
             )
 
         if metadata.annotations and metadata.annotations.get("ni/type_specialization") == "enum":

--- a/packages/generator/ni_measurement_plugin_sdk_generator/client/_support.py
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/client/_support.py
@@ -224,6 +224,11 @@ def get_configuration_parameters_with_type_and_default_values(
             else:
                 default_value = f"Path({default_value})"
 
+        if metadata.message_type and metadata.message_type == "ni.protobuf.types.DoubleXYData":
+            raise click.ClickException(
+                "Measurement configuration(s) with Double XY datatype is not supported."
+            )
+
         if metadata.annotations and metadata.annotations.get("ni/type_specialization") == "enum":
             enum_type = _get_enum_type(metadata, enum_values_by_type)
             parameter_type = enum_type.__name__

--- a/packages/generator/ni_measurement_plugin_sdk_generator/client/_support.py
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/client/_support.py
@@ -226,7 +226,7 @@ def get_configuration_parameters_with_type_and_default_values(
 
         if metadata.message_type:
             raise click.ClickException(
-                "Measurement configuration with Double XY datatype is not supported."
+                "Measurement configuration with message datatype is not supported."
             )
 
         if metadata.annotations and metadata.annotations.get("ni/type_specialization") == "enum":

--- a/packages/generator/ni_measurement_plugin_sdk_generator/client/_support.py
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/client/_support.py
@@ -224,7 +224,7 @@ def get_configuration_parameters_with_type_and_default_values(
             else:
                 default_value = f"Path({default_value})"
 
-        if metadata.message_type and metadata.message_type == "ni.protobuf.types.DoubleXYData":
+        if metadata.message_type:
             raise click.ClickException(
                 "Measurement configuration with Double XY datatype is not supported."
             )


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Raise an exception to show users that Double XY datatype is not supported, when creating a client for measurements configured with Double XY datatype as inputs.

### Why should this Pull Request be merged?

- Currently, Measurement Plug-In client generator doesn't support Double XY datatype. So, this implementation will state a exact issue of the client generation failure, instead of error stack trace.

### What testing has been done?

- Done manual testing.
- Existing test cases passed.