### PR TITLE
Do not specify version in the MeasurementService constructor

### DIFF
--- a/examples/game_of_life/game_of_life.serviceconfig
+++ b/examples/game_of_life/game_of_life.serviceconfig
@@ -2,6 +2,7 @@
   "services": [
     {
       "displayName": "Conway's Game of Life (Py)",
+      "version": "1.0.0.0",
       "serviceClass": "ni.examples.GameOfLife_Python",
       "descriptionUrl": "",
       "providedInterfaces": [

--- a/examples/game_of_life/game_of_life.serviceconfig
+++ b/examples/game_of_life/game_of_life.serviceconfig
@@ -2,7 +2,7 @@
   "services": [
     {
       "displayName": "Conway's Game of Life (Py)",
-      "version": "1.0.0.0",
+      "version": "1.0.0",
       "serviceClass": "ni.examples.GameOfLife_Python",
       "descriptionUrl": "",
       "providedInterfaces": [

--- a/examples/game_of_life/measurement.py
+++ b/examples/game_of_life/measurement.py
@@ -15,7 +15,7 @@ from ni_measurement_plugin_sdk_service._internal.stubs.ni.protobuf.types import 
 service_directory = pathlib.Path(__file__).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "game_of_life.serviceconfig",
-    version="1.0.0.0",
+    version="1.0.0",
     ui_file_paths=[service_directory / "game_of_life.measui"],
 )
 

--- a/examples/game_of_life/measurement.py
+++ b/examples/game_of_life/measurement.py
@@ -15,7 +15,6 @@ from ni_measurement_plugin_sdk_service._internal.stubs.ni.protobuf.types import 
 service_directory = pathlib.Path(__file__).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "game_of_life.serviceconfig",
-    version="1.0.0",
     ui_file_paths=[service_directory / "game_of_life.measui"],
 )
 

--- a/examples/game_of_life/measurement.py
+++ b/examples/game_of_life/measurement.py
@@ -15,6 +15,7 @@ from ni_measurement_plugin_sdk_service._internal.stubs.ni.protobuf.types import 
 service_directory = pathlib.Path(__file__).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "game_of_life.serviceconfig",
+    version="1.0.0.0",
     ui_file_paths=[service_directory / "game_of_life.measui"],
 )
 

--- a/examples/game_of_life/measurement.py
+++ b/examples/game_of_life/measurement.py
@@ -15,7 +15,6 @@ from ni_measurement_plugin_sdk_service._internal.stubs.ni.protobuf.types import 
 service_directory = pathlib.Path(__file__).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "game_of_life.serviceconfig",
-    version="1.0.0.0",
     ui_file_paths=[service_directory / "game_of_life.measui"],
 )
 

--- a/examples/game_of_life/pyproject.toml
+++ b/examples/game_of_life/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow_prereleases=true}
+ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow-prereleases = true}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 
 [tool.poetry.group.dev.dependencies]

--- a/examples/game_of_life/pyproject.toml
+++ b/examples/game_of_life/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-ni-measurement-plugin-sdk-service = {version = "^2.0.0"}
+ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow_prereleases=true}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 
 [tool.poetry.group.dev.dependencies]

--- a/examples/nidaqmx_analog_input/NIDAQmxAnalogInput.serviceconfig
+++ b/examples/nidaqmx_analog_input/NIDAQmxAnalogInput.serviceconfig
@@ -2,6 +2,7 @@
   "services": [
     {
       "displayName": "NI-DAQmx Analog Input (Py)",
+      "version": "1.0.0.0",
       "serviceClass": "ni.examples.NIDAQmxAnalogInput_Python",
       "descriptionUrl": "",
       "providedInterfaces": [

--- a/examples/nidaqmx_analog_input/NIDAQmxAnalogInput.serviceconfig
+++ b/examples/nidaqmx_analog_input/NIDAQmxAnalogInput.serviceconfig
@@ -2,7 +2,7 @@
   "services": [
     {
       "displayName": "NI-DAQmx Analog Input (Py)",
-      "version": "1.0.0.0",
+      "version": "1.0.0",
       "serviceClass": "ni.examples.NIDAQmxAnalogInput_Python",
       "descriptionUrl": "",
       "providedInterfaces": [

--- a/examples/nidaqmx_analog_input/measurement.py
+++ b/examples/nidaqmx_analog_input/measurement.py
@@ -17,7 +17,7 @@ script_or_exe = sys.executable if getattr(sys, "frozen", False) else __file__
 service_directory = pathlib.Path(script_or_exe).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "NIDAQmxAnalogInput.serviceconfig",
-    version="1.0.0.0",
+    version="1.0.0",
     ui_file_paths=[service_directory / "NIDAQmxAnalogInput.measui"],
 )
 

--- a/examples/nidaqmx_analog_input/measurement.py
+++ b/examples/nidaqmx_analog_input/measurement.py
@@ -17,6 +17,7 @@ script_or_exe = sys.executable if getattr(sys, "frozen", False) else __file__
 service_directory = pathlib.Path(script_or_exe).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "NIDAQmxAnalogInput.serviceconfig",
+    version="1.0.0.0",
     ui_file_paths=[service_directory / "NIDAQmxAnalogInput.measui"],
 )
 

--- a/examples/nidaqmx_analog_input/measurement.py
+++ b/examples/nidaqmx_analog_input/measurement.py
@@ -17,7 +17,6 @@ script_or_exe = sys.executable if getattr(sys, "frozen", False) else __file__
 service_directory = pathlib.Path(script_or_exe).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "NIDAQmxAnalogInput.serviceconfig",
-    version="0.1.0.0",
     ui_file_paths=[service_directory / "NIDAQmxAnalogInput.measui"],
 )
 

--- a/examples/nidaqmx_analog_input/measurement.py
+++ b/examples/nidaqmx_analog_input/measurement.py
@@ -17,7 +17,6 @@ script_or_exe = sys.executable if getattr(sys, "frozen", False) else __file__
 service_directory = pathlib.Path(script_or_exe).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "NIDAQmxAnalogInput.serviceconfig",
-    version="1.0.0",
     ui_file_paths=[service_directory / "NIDAQmxAnalogInput.measui"],
 )
 

--- a/examples/nidaqmx_analog_input/pyproject.toml
+++ b/examples/nidaqmx_analog_input/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 nidaqmx = { version = ">=0.8.0", extras = ["grpc"] }
-ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow_prereleases=true}
+ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow-prereleases = truereleases=true}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 
 [tool.poetry.group.dev.dependencies]

--- a/examples/nidaqmx_analog_input/pyproject.toml
+++ b/examples/nidaqmx_analog_input/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 nidaqmx = { version = ">=0.8.0", extras = ["grpc"] }
-ni-measurement-plugin-sdk-service = {version = "^2.0.0"}
+ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow_prereleases=true}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 
 [tool.poetry.group.dev.dependencies]

--- a/examples/nidaqmx_analog_input/pyproject.toml
+++ b/examples/nidaqmx_analog_input/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 nidaqmx = { version = ">=0.8.0", extras = ["grpc"] }
-ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow-prereleases = truereleases=true}
+ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow-prereleases = true}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 
 [tool.poetry.group.dev.dependencies]

--- a/examples/nidcpower_source_dc_voltage/NIDCPowerSourceDCVoltage.serviceconfig
+++ b/examples/nidcpower_source_dc_voltage/NIDCPowerSourceDCVoltage.serviceconfig
@@ -2,7 +2,7 @@
   "services": [
     {
       "displayName": "NI-DCPower Source DC Voltage (Py)",
-      "version": "1.0.0.0",
+      "version": "1.0.0",
       "serviceClass": "ni.examples.NIDCPowerSourceDCVoltage_Python",
       "descriptionUrl": "",
       "providedInterfaces": [

--- a/examples/nidcpower_source_dc_voltage/NIDCPowerSourceDCVoltage.serviceconfig
+++ b/examples/nidcpower_source_dc_voltage/NIDCPowerSourceDCVoltage.serviceconfig
@@ -2,6 +2,7 @@
   "services": [
     {
       "displayName": "NI-DCPower Source DC Voltage (Py)",
+      "version": "1.0.0.0",
       "serviceClass": "ni.examples.NIDCPowerSourceDCVoltage_Python",
       "descriptionUrl": "",
       "providedInterfaces": [

--- a/examples/nidcpower_source_dc_voltage/measurement.py
+++ b/examples/nidcpower_source_dc_voltage/measurement.py
@@ -29,7 +29,7 @@ script_or_exe = sys.executable if getattr(sys, "frozen", False) else __file__
 service_directory = pathlib.Path(script_or_exe).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "NIDCPowerSourceDCVoltage.serviceconfig",
-    version="1.0.0.0",
+    version="1.0.0",
     ui_file_paths=[
         service_directory / "NIDCPowerSourceDCVoltage.measui",
         service_directory / "NIDCPowerSourceDCVoltageUI.vi",

--- a/examples/nidcpower_source_dc_voltage/measurement.py
+++ b/examples/nidcpower_source_dc_voltage/measurement.py
@@ -29,7 +29,6 @@ script_or_exe = sys.executable if getattr(sys, "frozen", False) else __file__
 service_directory = pathlib.Path(script_or_exe).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "NIDCPowerSourceDCVoltage.serviceconfig",
-    version="1.0.0",
     ui_file_paths=[
         service_directory / "NIDCPowerSourceDCVoltage.measui",
         service_directory / "NIDCPowerSourceDCVoltageUI.vi",

--- a/examples/nidcpower_source_dc_voltage/measurement.py
+++ b/examples/nidcpower_source_dc_voltage/measurement.py
@@ -29,6 +29,7 @@ script_or_exe = sys.executable if getattr(sys, "frozen", False) else __file__
 service_directory = pathlib.Path(script_or_exe).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "NIDCPowerSourceDCVoltage.serviceconfig",
+    version="1.0.0.0",
     ui_file_paths=[
         service_directory / "NIDCPowerSourceDCVoltage.measui",
         service_directory / "NIDCPowerSourceDCVoltageUI.vi",

--- a/examples/nidcpower_source_dc_voltage/measurement.py
+++ b/examples/nidcpower_source_dc_voltage/measurement.py
@@ -29,7 +29,6 @@ script_or_exe = sys.executable if getattr(sys, "frozen", False) else __file__
 service_directory = pathlib.Path(script_or_exe).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "NIDCPowerSourceDCVoltage.serviceconfig",
-    version="0.1.0.0",
     ui_file_paths=[
         service_directory / "NIDCPowerSourceDCVoltage.measui",
         service_directory / "NIDCPowerSourceDCVoltageUI.vi",

--- a/examples/nidcpower_source_dc_voltage/pyproject.toml
+++ b/examples/nidcpower_source_dc_voltage/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 nidcpower = { version = ">=1.4.4", extras = ["grpc"] }
-ni-measurement-plugin-sdk-service = {version = "^2.0.0"}
+ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow_prereleases=true}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 

--- a/examples/nidcpower_source_dc_voltage/pyproject.toml
+++ b/examples/nidcpower_source_dc_voltage/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 nidcpower = { version = ">=1.4.4", extras = ["grpc"] }
-ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow-prereleases = truereleases=true}
+ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow-prereleases = true}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 

--- a/examples/nidcpower_source_dc_voltage/pyproject.toml
+++ b/examples/nidcpower_source_dc_voltage/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 nidcpower = { version = ">=1.4.4", extras = ["grpc"] }
-ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow_prereleases=true}
+ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow-prereleases = truereleases=true}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 

--- a/examples/nidcpower_source_dc_voltage_with_multiplexer/NIDCPowerSourceDCVoltageWithMultiplexer.serviceconfig
+++ b/examples/nidcpower_source_dc_voltage_with_multiplexer/NIDCPowerSourceDCVoltageWithMultiplexer.serviceconfig
@@ -2,6 +2,7 @@
   "services": [
     {
       "displayName": "NI-DCPower Source DC Voltage With Multiplexer (Py)",
+      "version": "1.0.0.0",
       "serviceClass": "ni.examples.NIDCPowerSourceDCVoltageWithMultiplexer_Python",
       "descriptionUrl": "",
       "providedInterfaces": [

--- a/examples/nidcpower_source_dc_voltage_with_multiplexer/NIDCPowerSourceDCVoltageWithMultiplexer.serviceconfig
+++ b/examples/nidcpower_source_dc_voltage_with_multiplexer/NIDCPowerSourceDCVoltageWithMultiplexer.serviceconfig
@@ -2,7 +2,7 @@
   "services": [
     {
       "displayName": "NI-DCPower Source DC Voltage With Multiplexer (Py)",
-      "version": "1.0.0.0",
+      "version": "1.0.0",
       "serviceClass": "ni.examples.NIDCPowerSourceDCVoltageWithMultiplexer_Python",
       "descriptionUrl": "",
       "providedInterfaces": [

--- a/examples/nidcpower_source_dc_voltage_with_multiplexer/measurement.py
+++ b/examples/nidcpower_source_dc_voltage_with_multiplexer/measurement.py
@@ -29,7 +29,6 @@ script_or_exe = sys.executable if getattr(sys, "frozen", False) else __file__
 service_directory = pathlib.Path(script_or_exe).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "NIDCPowerSourceDCVoltageWithMultiplexer.serviceconfig",
-    version="0.1.0.0",
     ui_file_paths=[service_directory / "NIDCPowerSourceDCVoltageWithMultiplexer.measui"],
 )
 

--- a/examples/nidcpower_source_dc_voltage_with_multiplexer/measurement.py
+++ b/examples/nidcpower_source_dc_voltage_with_multiplexer/measurement.py
@@ -29,7 +29,7 @@ script_or_exe = sys.executable if getattr(sys, "frozen", False) else __file__
 service_directory = pathlib.Path(script_or_exe).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "NIDCPowerSourceDCVoltageWithMultiplexer.serviceconfig",
-    version="1.0.0.0",
+    version="1.0.0",
     ui_file_paths=[service_directory / "NIDCPowerSourceDCVoltageWithMultiplexer.measui"],
 )
 

--- a/examples/nidcpower_source_dc_voltage_with_multiplexer/measurement.py
+++ b/examples/nidcpower_source_dc_voltage_with_multiplexer/measurement.py
@@ -29,6 +29,7 @@ script_or_exe = sys.executable if getattr(sys, "frozen", False) else __file__
 service_directory = pathlib.Path(script_or_exe).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "NIDCPowerSourceDCVoltageWithMultiplexer.serviceconfig",
+    version="1.0.0.0",
     ui_file_paths=[service_directory / "NIDCPowerSourceDCVoltageWithMultiplexer.measui"],
 )
 

--- a/examples/nidcpower_source_dc_voltage_with_multiplexer/measurement.py
+++ b/examples/nidcpower_source_dc_voltage_with_multiplexer/measurement.py
@@ -29,7 +29,6 @@ script_or_exe = sys.executable if getattr(sys, "frozen", False) else __file__
 service_directory = pathlib.Path(script_or_exe).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "NIDCPowerSourceDCVoltageWithMultiplexer.serviceconfig",
-    version="1.0.0",
     ui_file_paths=[service_directory / "NIDCPowerSourceDCVoltageWithMultiplexer.measui"],
 )
 

--- a/examples/nidcpower_source_dc_voltage_with_multiplexer/pyproject.toml
+++ b/examples/nidcpower_source_dc_voltage_with_multiplexer/pyproject.toml
@@ -9,7 +9,7 @@ authors = ["National Instruments"]
 python = "^3.8"
 nidcpower = { version = ">=1.4.4", extras = ["grpc"] }
 niswitch = { version = ">=1.4.4", extras = ["grpc"] }
-ni-measurement-plugin-sdk-service = {version = "^2.0.0"}
+ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow_prereleases=true}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 

--- a/examples/nidcpower_source_dc_voltage_with_multiplexer/pyproject.toml
+++ b/examples/nidcpower_source_dc_voltage_with_multiplexer/pyproject.toml
@@ -9,7 +9,7 @@ authors = ["National Instruments"]
 python = "^3.8"
 nidcpower = { version = ">=1.4.4", extras = ["grpc"] }
 niswitch = { version = ">=1.4.4", extras = ["grpc"] }
-ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow_prereleases=true}
+ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow-prereleases = truereleases=true}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 

--- a/examples/nidcpower_source_dc_voltage_with_multiplexer/pyproject.toml
+++ b/examples/nidcpower_source_dc_voltage_with_multiplexer/pyproject.toml
@@ -9,7 +9,7 @@ authors = ["National Instruments"]
 python = "^3.8"
 nidcpower = { version = ">=1.4.4", extras = ["grpc"] }
 niswitch = { version = ">=1.4.4", extras = ["grpc"] }
-ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow-prereleases = truereleases=true}
+ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow-prereleases = true}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 

--- a/examples/nidigital_spi/NIDigitalSPI.serviceconfig
+++ b/examples/nidigital_spi/NIDigitalSPI.serviceconfig
@@ -2,7 +2,7 @@
   "services": [
     {
       "displayName": "NI-Digital SPI (Py)",
-      "version": "1.0.0.0",
+      "version": "1.0.0",
       "serviceClass": "ni.examples.NIDigitalSPI_Python",
       "descriptionUrl": "",
       "providedInterfaces": [

--- a/examples/nidigital_spi/NIDigitalSPI.serviceconfig
+++ b/examples/nidigital_spi/NIDigitalSPI.serviceconfig
@@ -2,6 +2,7 @@
   "services": [
     {
       "displayName": "NI-Digital SPI (Py)",
+      "version": "1.0.0.0",
       "serviceClass": "ni.examples.NIDigitalSPI_Python",
       "descriptionUrl": "",
       "providedInterfaces": [

--- a/examples/nidigital_spi/measurement.py
+++ b/examples/nidigital_spi/measurement.py
@@ -14,7 +14,6 @@ script_or_exe = sys.executable if getattr(sys, "frozen", False) else __file__
 service_directory = pathlib.Path(script_or_exe).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "NIDigitalSPI.serviceconfig",
-    version="0.1.0.0",
     ui_file_paths=[service_directory / "NIDigitalSPI.measui"],
 )
 

--- a/examples/nidigital_spi/measurement.py
+++ b/examples/nidigital_spi/measurement.py
@@ -14,6 +14,7 @@ script_or_exe = sys.executable if getattr(sys, "frozen", False) else __file__
 service_directory = pathlib.Path(script_or_exe).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "NIDigitalSPI.serviceconfig",
+    version="1.0.0.0",
     ui_file_paths=[service_directory / "NIDigitalSPI.measui"],
 )
 

--- a/examples/nidigital_spi/measurement.py
+++ b/examples/nidigital_spi/measurement.py
@@ -14,7 +14,6 @@ script_or_exe = sys.executable if getattr(sys, "frozen", False) else __file__
 service_directory = pathlib.Path(script_or_exe).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "NIDigitalSPI.serviceconfig",
-    version="1.0.0",
     ui_file_paths=[service_directory / "NIDigitalSPI.measui"],
 )
 

--- a/examples/nidigital_spi/measurement.py
+++ b/examples/nidigital_spi/measurement.py
@@ -14,7 +14,7 @@ script_or_exe = sys.executable if getattr(sys, "frozen", False) else __file__
 service_directory = pathlib.Path(script_or_exe).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "NIDigitalSPI.serviceconfig",
-    version="1.0.0.0",
+    version="1.0.0",
     ui_file_paths=[service_directory / "NIDigitalSPI.measui"],
 )
 

--- a/examples/nidigital_spi/pyproject.toml
+++ b/examples/nidigital_spi/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 nidigital = { version = ">=1.4.4", extras = ["grpc"] }
-ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow-prereleases = truereleases=true}
+ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow-prereleases = true}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 

--- a/examples/nidigital_spi/pyproject.toml
+++ b/examples/nidigital_spi/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 nidigital = { version = ">=1.4.4", extras = ["grpc"] }
-ni-measurement-plugin-sdk-service = {version = "^2.0.0"}
+ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow_prereleases=true}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 

--- a/examples/nidigital_spi/pyproject.toml
+++ b/examples/nidigital_spi/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 nidigital = { version = ">=1.4.4", extras = ["grpc"] }
-ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow_prereleases=true}
+ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow-prereleases = truereleases=true}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 

--- a/examples/nidmm_measurement/NIDmmMeasurement.serviceconfig
+++ b/examples/nidmm_measurement/NIDmmMeasurement.serviceconfig
@@ -2,7 +2,7 @@
   "services": [
     {
       "displayName": "NI-DMM Measurement (Py)",
-      "version": "1.0.0.0",
+      "version": "1.0.0",
       "serviceClass": "ni.examples.NIDmmMeasurement_Python",
       "descriptionUrl": "",
       "providedInterfaces": [

--- a/examples/nidmm_measurement/NIDmmMeasurement.serviceconfig
+++ b/examples/nidmm_measurement/NIDmmMeasurement.serviceconfig
@@ -2,6 +2,7 @@
   "services": [
     {
       "displayName": "NI-DMM Measurement (Py)",
+      "version": "1.0.0.0",
       "serviceClass": "ni.examples.NIDmmMeasurement_Python",
       "descriptionUrl": "",
       "providedInterfaces": [

--- a/examples/nidmm_measurement/measurement.py
+++ b/examples/nidmm_measurement/measurement.py
@@ -16,7 +16,6 @@ script_or_exe = sys.executable if getattr(sys, "frozen", False) else __file__
 service_directory = pathlib.Path(script_or_exe).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "NIDmmMeasurement.serviceconfig",
-    version="0.1.0.0",
     ui_file_paths=[service_directory / "NIDmmMeasurement.measui"],
 )
 

--- a/examples/nidmm_measurement/measurement.py
+++ b/examples/nidmm_measurement/measurement.py
@@ -16,6 +16,7 @@ script_or_exe = sys.executable if getattr(sys, "frozen", False) else __file__
 service_directory = pathlib.Path(script_or_exe).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "NIDmmMeasurement.serviceconfig",
+    version="1.0.0.0",
     ui_file_paths=[service_directory / "NIDmmMeasurement.measui"],
 )
 

--- a/examples/nidmm_measurement/measurement.py
+++ b/examples/nidmm_measurement/measurement.py
@@ -16,7 +16,7 @@ script_or_exe = sys.executable if getattr(sys, "frozen", False) else __file__
 service_directory = pathlib.Path(script_or_exe).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "NIDmmMeasurement.serviceconfig",
-    version="1.0.0.0",
+    version="1.0.0",
     ui_file_paths=[service_directory / "NIDmmMeasurement.measui"],
 )
 

--- a/examples/nidmm_measurement/measurement.py
+++ b/examples/nidmm_measurement/measurement.py
@@ -16,7 +16,6 @@ script_or_exe = sys.executable if getattr(sys, "frozen", False) else __file__
 service_directory = pathlib.Path(script_or_exe).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "NIDmmMeasurement.serviceconfig",
-    version="1.0.0",
     ui_file_paths=[service_directory / "NIDmmMeasurement.measui"],
 )
 

--- a/examples/nidmm_measurement/pyproject.toml
+++ b/examples/nidmm_measurement/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 nidmm = { version = ">=1.4.4", extras = ["grpc"] }
-ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow-prereleases = truereleases=true}
+ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow-prereleases = true}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 

--- a/examples/nidmm_measurement/pyproject.toml
+++ b/examples/nidmm_measurement/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 nidmm = { version = ">=1.4.4", extras = ["grpc"] }
-ni-measurement-plugin-sdk-service = {version = "^2.0.0"}
+ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow_prereleases=true}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 

--- a/examples/nidmm_measurement/pyproject.toml
+++ b/examples/nidmm_measurement/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 nidmm = { version = ">=1.4.4", extras = ["grpc"] }
-ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow_prereleases=true}
+ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow-prereleases = truereleases=true}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 

--- a/examples/nifgen_standard_function/NIFgenStandardFunction.serviceconfig
+++ b/examples/nifgen_standard_function/NIFgenStandardFunction.serviceconfig
@@ -2,6 +2,7 @@
   "services": [
     {
       "displayName": "NI-FGEN Standard Function (Py)",
+      "version": "1.0.0.0",
       "serviceClass": "ni.examples.NIFgenStandardFunction_Python",
       "descriptionUrl": "",
       "providedInterfaces": [

--- a/examples/nifgen_standard_function/NIFgenStandardFunction.serviceconfig
+++ b/examples/nifgen_standard_function/NIFgenStandardFunction.serviceconfig
@@ -2,7 +2,7 @@
   "services": [
     {
       "displayName": "NI-FGEN Standard Function (Py)",
-      "version": "1.0.0.0",
+      "version": "1.0.0",
       "serviceClass": "ni.examples.NIFgenStandardFunction_Python",
       "descriptionUrl": "",
       "providedInterfaces": [

--- a/examples/nifgen_standard_function/measurement.py
+++ b/examples/nifgen_standard_function/measurement.py
@@ -27,7 +27,6 @@ script_or_exe = sys.executable if getattr(sys, "frozen", False) else __file__
 service_directory = pathlib.Path(script_or_exe).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "NIFgenStandardFunction.serviceconfig",
-    version="0.1.0.0",
     ui_file_paths=[service_directory / "NIFgenStandardFunction.measui"],
 )
 

--- a/examples/nifgen_standard_function/measurement.py
+++ b/examples/nifgen_standard_function/measurement.py
@@ -27,7 +27,6 @@ script_or_exe = sys.executable if getattr(sys, "frozen", False) else __file__
 service_directory = pathlib.Path(script_or_exe).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "NIFgenStandardFunction.serviceconfig",
-    version="1.0.0",
     ui_file_paths=[service_directory / "NIFgenStandardFunction.measui"],
 )
 

--- a/examples/nifgen_standard_function/measurement.py
+++ b/examples/nifgen_standard_function/measurement.py
@@ -27,7 +27,7 @@ script_or_exe = sys.executable if getattr(sys, "frozen", False) else __file__
 service_directory = pathlib.Path(script_or_exe).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "NIFgenStandardFunction.serviceconfig",
-    version="1.0.0.0",
+    version="1.0.0",
     ui_file_paths=[service_directory / "NIFgenStandardFunction.measui"],
 )
 

--- a/examples/nifgen_standard_function/measurement.py
+++ b/examples/nifgen_standard_function/measurement.py
@@ -27,6 +27,7 @@ script_or_exe = sys.executable if getattr(sys, "frozen", False) else __file__
 service_directory = pathlib.Path(script_or_exe).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "NIFgenStandardFunction.serviceconfig",
+    version="1.0.0.0",
     ui_file_paths=[service_directory / "NIFgenStandardFunction.measui"],
 )
 

--- a/examples/nifgen_standard_function/pyproject.toml
+++ b/examples/nifgen_standard_function/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 nifgen = { version = ">=1.4.4", extras = ["grpc"] }
-ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow_prereleases=true}
+ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow-prereleases = truereleases=true}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 

--- a/examples/nifgen_standard_function/pyproject.toml
+++ b/examples/nifgen_standard_function/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 nifgen = { version = ">=1.4.4", extras = ["grpc"] }
-ni-measurement-plugin-sdk-service = {version = "^2.0.0"}
+ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow_prereleases=true}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 

--- a/examples/nifgen_standard_function/pyproject.toml
+++ b/examples/nifgen_standard_function/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 nifgen = { version = ">=1.4.4", extras = ["grpc"] }
-ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow-prereleases = truereleases=true}
+ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow-prereleases = true}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 

--- a/examples/niscope_acquire_waveform/NIScopeAcquireWaveform.serviceconfig
+++ b/examples/niscope_acquire_waveform/NIScopeAcquireWaveform.serviceconfig
@@ -2,6 +2,7 @@
   "services": [
     {
       "displayName": "NI-SCOPE Acquire Waveform (Py)",
+      "version": "1.0.0.0",
       "serviceClass": "ni.examples.NIScopeAcquireWaveform_Python",
       "descriptionUrl": "",
       "providedInterfaces": [

--- a/examples/niscope_acquire_waveform/NIScopeAcquireWaveform.serviceconfig
+++ b/examples/niscope_acquire_waveform/NIScopeAcquireWaveform.serviceconfig
@@ -2,7 +2,7 @@
   "services": [
     {
       "displayName": "NI-SCOPE Acquire Waveform (Py)",
-      "version": "1.0.0.0",
+      "version": "1.0.0",
       "serviceClass": "ni.examples.NIScopeAcquireWaveform_Python",
       "descriptionUrl": "",
       "providedInterfaces": [

--- a/examples/niscope_acquire_waveform/measurement.py
+++ b/examples/niscope_acquire_waveform/measurement.py
@@ -17,6 +17,7 @@ script_or_exe = sys.executable if getattr(sys, "frozen", False) else __file__
 service_directory = pathlib.Path(script_or_exe).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "NIScopeAcquireWaveform.serviceconfig",
+    version="1.0.0.0",
     ui_file_paths=[service_directory / "NIScopeAcquireWaveform.measui"],
 )
 

--- a/examples/niscope_acquire_waveform/measurement.py
+++ b/examples/niscope_acquire_waveform/measurement.py
@@ -17,7 +17,7 @@ script_or_exe = sys.executable if getattr(sys, "frozen", False) else __file__
 service_directory = pathlib.Path(script_or_exe).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "NIScopeAcquireWaveform.serviceconfig",
-    version="1.0.0.0",
+    version="1.0.0",
     ui_file_paths=[service_directory / "NIScopeAcquireWaveform.measui"],
 )
 

--- a/examples/niscope_acquire_waveform/measurement.py
+++ b/examples/niscope_acquire_waveform/measurement.py
@@ -17,7 +17,6 @@ script_or_exe = sys.executable if getattr(sys, "frozen", False) else __file__
 service_directory = pathlib.Path(script_or_exe).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "NIScopeAcquireWaveform.serviceconfig",
-    version="0.1.0.0",
     ui_file_paths=[service_directory / "NIScopeAcquireWaveform.measui"],
 )
 

--- a/examples/niscope_acquire_waveform/measurement.py
+++ b/examples/niscope_acquire_waveform/measurement.py
@@ -17,7 +17,6 @@ script_or_exe = sys.executable if getattr(sys, "frozen", False) else __file__
 service_directory = pathlib.Path(script_or_exe).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "NIScopeAcquireWaveform.serviceconfig",
-    version="1.0.0",
     ui_file_paths=[service_directory / "NIScopeAcquireWaveform.measui"],
 )
 

--- a/examples/niscope_acquire_waveform/pyproject.toml
+++ b/examples/niscope_acquire_waveform/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 niscope = { version = ">=1.4.4", extras = ["grpc"] }
-ni-measurement-plugin-sdk-service = {version = "^2.0.0"}
+ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow_prereleases=true}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 

--- a/examples/niscope_acquire_waveform/pyproject.toml
+++ b/examples/niscope_acquire_waveform/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 niscope = { version = ">=1.4.4", extras = ["grpc"] }
-ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow_prereleases=true}
+ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow-prereleases = truereleases=true}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 

--- a/examples/niscope_acquire_waveform/pyproject.toml
+++ b/examples/niscope_acquire_waveform/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 niscope = { version = ">=1.4.4", extras = ["grpc"] }
-ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow-prereleases = truereleases=true}
+ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow-prereleases = true}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 

--- a/examples/niswitch_control_relays/NISwitchControlRelays.serviceconfig
+++ b/examples/niswitch_control_relays/NISwitchControlRelays.serviceconfig
@@ -2,7 +2,7 @@
   "services": [
     {
       "displayName": "NI-SWITCH Control Relays (Py)",
-      "version": "1.0.0.0",
+      "version": "1.0.0",
       "serviceClass": "ni.examples.NISwitchControlRelays_Python",
       "descriptionUrl": "",
       "providedInterfaces": [

--- a/examples/niswitch_control_relays/NISwitchControlRelays.serviceconfig
+++ b/examples/niswitch_control_relays/NISwitchControlRelays.serviceconfig
@@ -2,6 +2,7 @@
   "services": [
     {
       "displayName": "NI-SWITCH Control Relays (Py)",
+      "version": "1.0.0.0",
       "serviceClass": "ni.examples.NISwitchControlRelays_Python",
       "descriptionUrl": "",
       "providedInterfaces": [

--- a/examples/niswitch_control_relays/measurement.py
+++ b/examples/niswitch_control_relays/measurement.py
@@ -14,7 +14,7 @@ script_or_exe = sys.executable if getattr(sys, "frozen", False) else __file__
 service_directory = pathlib.Path(script_or_exe).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "NISwitchControlRelays.serviceconfig",
-    version="1.0.0.0",
+    version="1.0.0",
     ui_file_paths=[service_directory / "NISwitchControlRelays.measui"],
 )
 

--- a/examples/niswitch_control_relays/measurement.py
+++ b/examples/niswitch_control_relays/measurement.py
@@ -14,7 +14,6 @@ script_or_exe = sys.executable if getattr(sys, "frozen", False) else __file__
 service_directory = pathlib.Path(script_or_exe).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "NISwitchControlRelays.serviceconfig",
-    version="0.1.0.0",
     ui_file_paths=[service_directory / "NISwitchControlRelays.measui"],
 )
 

--- a/examples/niswitch_control_relays/measurement.py
+++ b/examples/niswitch_control_relays/measurement.py
@@ -14,7 +14,6 @@ script_or_exe = sys.executable if getattr(sys, "frozen", False) else __file__
 service_directory = pathlib.Path(script_or_exe).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "NISwitchControlRelays.serviceconfig",
-    version="1.0.0",
     ui_file_paths=[service_directory / "NISwitchControlRelays.measui"],
 )
 

--- a/examples/niswitch_control_relays/measurement.py
+++ b/examples/niswitch_control_relays/measurement.py
@@ -14,6 +14,7 @@ script_or_exe = sys.executable if getattr(sys, "frozen", False) else __file__
 service_directory = pathlib.Path(script_or_exe).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "NISwitchControlRelays.serviceconfig",
+    version="1.0.0.0",
     ui_file_paths=[service_directory / "NISwitchControlRelays.measui"],
 )
 

--- a/examples/niswitch_control_relays/pyproject.toml
+++ b/examples/niswitch_control_relays/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 niswitch = { version = ">=1.4.4", extras = ["grpc"] }
-ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow-prereleases = truereleases=true}
+ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow-prereleases = true}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 

--- a/examples/niswitch_control_relays/pyproject.toml
+++ b/examples/niswitch_control_relays/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 niswitch = { version = ">=1.4.4", extras = ["grpc"] }
-ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow_prereleases=true}
+ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow-prereleases = truereleases=true}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 

--- a/examples/niswitch_control_relays/pyproject.toml
+++ b/examples/niswitch_control_relays/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 niswitch = { version = ">=1.4.4", extras = ["grpc"] }
-ni-measurement-plugin-sdk-service = {version = "^2.0.0"}
+ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow_prereleases=true}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 

--- a/examples/nivisa_dmm_measurement/NIVisaDmmMeasurement.serviceconfig
+++ b/examples/nivisa_dmm_measurement/NIVisaDmmMeasurement.serviceconfig
@@ -2,7 +2,7 @@
   "services": [
     {
       "displayName": "NI-VISA DMM Measurement (Py)",
-      "version": "1.0.0.0",
+      "version": "1.0.0",
       "serviceClass": "ni.examples.NIVisaDmmMeasurement_Python",
       "descriptionUrl": "",
       "providedInterfaces": [

--- a/examples/nivisa_dmm_measurement/NIVisaDmmMeasurement.serviceconfig
+++ b/examples/nivisa_dmm_measurement/NIVisaDmmMeasurement.serviceconfig
@@ -2,6 +2,7 @@
   "services": [
     {
       "displayName": "NI-VISA DMM Measurement (Py)",
+      "version": "1.0.0.0",
       "serviceClass": "ni.examples.NIVisaDmmMeasurement_Python",
       "descriptionUrl": "",
       "providedInterfaces": [

--- a/examples/nivisa_dmm_measurement/measurement.py
+++ b/examples/nivisa_dmm_measurement/measurement.py
@@ -16,7 +16,7 @@ script_or_exe = sys.executable if getattr(sys, "frozen", False) else __file__
 service_directory = pathlib.Path(script_or_exe).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "NIVisaDmmMeasurement.serviceconfig",
-    version="1.0.0.0",
+    version="1.0.0",
     ui_file_paths=[service_directory / "NIVisaDmmMeasurement.measui"],
 )
 

--- a/examples/nivisa_dmm_measurement/measurement.py
+++ b/examples/nivisa_dmm_measurement/measurement.py
@@ -16,7 +16,6 @@ script_or_exe = sys.executable if getattr(sys, "frozen", False) else __file__
 service_directory = pathlib.Path(script_or_exe).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "NIVisaDmmMeasurement.serviceconfig",
-    version="1.0.0",
     ui_file_paths=[service_directory / "NIVisaDmmMeasurement.measui"],
 )
 

--- a/examples/nivisa_dmm_measurement/measurement.py
+++ b/examples/nivisa_dmm_measurement/measurement.py
@@ -16,6 +16,7 @@ script_or_exe = sys.executable if getattr(sys, "frozen", False) else __file__
 service_directory = pathlib.Path(script_or_exe).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "NIVisaDmmMeasurement.serviceconfig",
+    version="1.0.0.0",
     ui_file_paths=[service_directory / "NIVisaDmmMeasurement.measui"],
 )
 

--- a/examples/nivisa_dmm_measurement/measurement.py
+++ b/examples/nivisa_dmm_measurement/measurement.py
@@ -16,7 +16,6 @@ script_or_exe = sys.executable if getattr(sys, "frozen", False) else __file__
 service_directory = pathlib.Path(script_or_exe).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "NIVisaDmmMeasurement.serviceconfig",
-    version="0.1.0.0",
     ui_file_paths=[service_directory / "NIVisaDmmMeasurement.measui"],
 )
 

--- a/examples/nivisa_dmm_measurement/pyproject.toml
+++ b/examples/nivisa_dmm_measurement/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-ni-measurement-plugin-sdk-service = {version = "^2.0.0"}
+ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow_prereleases=true}
 PyVISA = "^1.13.0"
 PyVISA-sim = "^0.5.1"
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558

--- a/examples/nivisa_dmm_measurement/pyproject.toml
+++ b/examples/nivisa_dmm_measurement/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow_prereleases=true}
+ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow-prereleases = truereleases=true}
 PyVISA = "^1.13.0"
 PyVISA-sim = "^0.5.1"
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558

--- a/examples/nivisa_dmm_measurement/pyproject.toml
+++ b/examples/nivisa_dmm_measurement/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow-prereleases = truereleases=true}
+ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow-prereleases = true}
 PyVISA = "^1.13.0"
 PyVISA-sim = "^0.5.1"
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558

--- a/examples/output_voltage_measurement/OutputVoltageMeasurement.serviceconfig
+++ b/examples/output_voltage_measurement/OutputVoltageMeasurement.serviceconfig
@@ -2,6 +2,7 @@
   "services": [
     {
       "displayName": "Output Voltage Measurement (Py)",
+      "version": "1.0.0.0",
       "serviceClass": "ni.examples.OutputVoltageMeasurement_Python",
       "descriptionUrl": "",
       "providedInterfaces": [

--- a/examples/output_voltage_measurement/OutputVoltageMeasurement.serviceconfig
+++ b/examples/output_voltage_measurement/OutputVoltageMeasurement.serviceconfig
@@ -2,7 +2,7 @@
   "services": [
     {
       "displayName": "Output Voltage Measurement (Py)",
-      "version": "1.0.0.0",
+      "version": "1.0.0",
       "serviceClass": "ni.examples.OutputVoltageMeasurement_Python",
       "descriptionUrl": "",
       "providedInterfaces": [

--- a/examples/output_voltage_measurement/measurement.py
+++ b/examples/output_voltage_measurement/measurement.py
@@ -27,7 +27,6 @@ _NIDCPOWER_TIMEOUT_ERROR_CODES = [
 service_directory = pathlib.Path(__file__).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "OutputVoltageMeasurement.serviceconfig",
-    version="1.0.0.0",
     ui_file_paths=[service_directory / "OutputVoltageMeasurement.measui"],
 )
 

--- a/examples/output_voltage_measurement/measurement.py
+++ b/examples/output_voltage_measurement/measurement.py
@@ -27,7 +27,7 @@ _NIDCPOWER_TIMEOUT_ERROR_CODES = [
 service_directory = pathlib.Path(__file__).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "OutputVoltageMeasurement.serviceconfig",
-    version="1.0.0.0",
+    version="1.0.0",
     ui_file_paths=[service_directory / "OutputVoltageMeasurement.measui"],
 )
 

--- a/examples/output_voltage_measurement/measurement.py
+++ b/examples/output_voltage_measurement/measurement.py
@@ -27,7 +27,6 @@ _NIDCPOWER_TIMEOUT_ERROR_CODES = [
 service_directory = pathlib.Path(__file__).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "OutputVoltageMeasurement.serviceconfig",
-    version="1.0.0",
     ui_file_paths=[service_directory / "OutputVoltageMeasurement.measui"],
 )
 

--- a/examples/output_voltage_measurement/measurement.py
+++ b/examples/output_voltage_measurement/measurement.py
@@ -27,6 +27,7 @@ _NIDCPOWER_TIMEOUT_ERROR_CODES = [
 service_directory = pathlib.Path(__file__).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "OutputVoltageMeasurement.serviceconfig",
+    version="1.0.0.0",
     ui_file_paths=[service_directory / "OutputVoltageMeasurement.measui"],
 )
 

--- a/examples/output_voltage_measurement/pyproject.toml
+++ b/examples/output_voltage_measurement/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow-prereleases = truereleases=true}
+ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow-prereleases = true}
 PyVISA = "^1.13.0"
 PyVISA-sim = "^0.5.1"
 nidcpower = { version = ">=1.4.4", extras = ["grpc"] }

--- a/examples/output_voltage_measurement/pyproject.toml
+++ b/examples/output_voltage_measurement/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow_prereleases=true}
+ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow-prereleases = truereleases=true}
 PyVISA = "^1.13.0"
 PyVISA-sim = "^0.5.1"
 nidcpower = { version = ">=1.4.4", extras = ["grpc"] }

--- a/examples/output_voltage_measurement/pyproject.toml
+++ b/examples/output_voltage_measurement/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-ni-measurement-plugin-sdk-service = {version = "^2.0.0"}
+ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow_prereleases=true}
 PyVISA = "^1.13.0"
 PyVISA-sim = "^0.5.1"
 nidcpower = { version = ">=1.4.4", extras = ["grpc"] }

--- a/examples/sample_measurement/SampleMeasurement.serviceconfig
+++ b/examples/sample_measurement/SampleMeasurement.serviceconfig
@@ -2,6 +2,7 @@
   "services": [
     {
       "displayName": "Sample Measurement (Py)",
+      "version": "1.0.0.0",
       "serviceClass": "ni.examples.SampleMeasurement_Python",
       "descriptionUrl": "",
       "providedInterfaces": [

--- a/examples/sample_measurement/SampleMeasurement.serviceconfig
+++ b/examples/sample_measurement/SampleMeasurement.serviceconfig
@@ -2,7 +2,7 @@
   "services": [
     {
       "displayName": "Sample Measurement (Py)",
-      "version": "1.0.0.0",
+      "version": "1.0.0",
       "serviceClass": "ni.examples.SampleMeasurement_Python",
       "descriptionUrl": "",
       "providedInterfaces": [

--- a/examples/sample_measurement/measurement.py
+++ b/examples/sample_measurement/measurement.py
@@ -19,7 +19,6 @@ script_or_exe = sys.executable if getattr(sys, "frozen", False) else __file__
 service_directory = pathlib.Path(script_or_exe).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "SampleMeasurement.serviceconfig",
-    version="0.1.0.0",
     ui_file_paths=[
         service_directory / "SampleMeasurement.measui",
         service_directory / "SampleAllParameters.measui",

--- a/examples/sample_measurement/measurement.py
+++ b/examples/sample_measurement/measurement.py
@@ -19,6 +19,7 @@ script_or_exe = sys.executable if getattr(sys, "frozen", False) else __file__
 service_directory = pathlib.Path(script_or_exe).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "SampleMeasurement.serviceconfig",
+    version="1.0.0.0",
     ui_file_paths=[
         service_directory / "SampleMeasurement.measui",
         service_directory / "SampleAllParameters.measui",

--- a/examples/sample_measurement/measurement.py
+++ b/examples/sample_measurement/measurement.py
@@ -19,7 +19,7 @@ script_or_exe = sys.executable if getattr(sys, "frozen", False) else __file__
 service_directory = pathlib.Path(script_or_exe).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "SampleMeasurement.serviceconfig",
-    version="1.0.0.0",
+    version="1.0.0",
     ui_file_paths=[
         service_directory / "SampleMeasurement.measui",
         service_directory / "SampleAllParameters.measui",

--- a/examples/sample_measurement/measurement.py
+++ b/examples/sample_measurement/measurement.py
@@ -19,7 +19,6 @@ script_or_exe = sys.executable if getattr(sys, "frozen", False) else __file__
 service_directory = pathlib.Path(script_or_exe).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "SampleMeasurement.serviceconfig",
-    version="1.0.0",
     ui_file_paths=[
         service_directory / "SampleMeasurement.measui",
         service_directory / "SampleAllParameters.measui",

--- a/examples/sample_measurement/pyproject.toml
+++ b/examples/sample_measurement/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow-prereleases = truereleases=true}
+ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow-prereleases = true}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 
 [tool.poetry.group.dev.dependencies]

--- a/examples/sample_measurement/pyproject.toml
+++ b/examples/sample_measurement/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow_prereleases=true}
+ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow-prereleases = truereleases=true}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 
 [tool.poetry.group.dev.dependencies]

--- a/examples/sample_measurement/pyproject.toml
+++ b/examples/sample_measurement/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-ni-measurement-plugin-sdk-service = {version = "^2.0.0"}
+ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev0", allow_prereleases=true}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Specified the same version 1.0.0.0 for all examples in measurement.py and .serviceconfig file.

### Why should this Pull Request be merged?

With 2.1.0-dev0 or greater, this version will be used to register the service. Many of the examples were using '0.1.0.0'. When TestStand tries to access a measurement, it uses '1.0.0' for the default version. So we could specify 1.0.0.0 in the .serviceconfig file and / or we could do  this.

### What testing has been done?

Testing the installed examples locally.