### PR TITLE
[High Priority] Update default value for the pin map sites

### DIFF
--- a/packages/generator/ni_measurement_plugin_sdk_generator/client/templates/measurement_plugin_client.py.mako
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/client/templates/measurement_plugin_client.py.mako
@@ -118,7 +118,7 @@ class ${class_name}:
         if grpc_channel is not None:
             self._stub = v2_measurement_service_pb2_grpc.MeasurementServiceStub(grpc_channel)
         self._create_file_descriptor()
-        self._pin_map_context: Optional[PinMapContext] = None
+        self._pin_map_context: PinMapContext = PinMapContext(pin_map_id="", sites=[0])
 
     @property
     def pin_map_context(self) -> PinMapContext:
@@ -136,8 +136,7 @@ class ${class_name}:
     @property
     def sites(self) -> List[int]:
         """The sites where the measurement must be executed."""
-        if self._pin_map_context is not None:
-            return self._pin_map_context.sites
+        return self._pin_map_context.sites
 
     @sites.setter
     def sites(self, val: List[int]) -> None:
@@ -206,7 +205,7 @@ class ${class_name}:
         )
         return v2_measurement_service_pb2.MeasureRequest(
             configuration_parameters=serialized_configuration,
-            pin_map_context=self._pin_map_context._to_grpc() if self._pin_map_context else None,
+            pin_map_context=self._pin_map_context._to_grpc(),
         )
 
     % if output_metadata:
@@ -298,10 +297,7 @@ class ${class_name}:
             pin_map_path: Absolute path of the pin map file.
         """
         pin_map_id = self._get_pin_map_client().update_pin_map(pin_map_path)
-        if self._pin_map_context is None:
-            self._pin_map_context = PinMapContext(pin_map_id=pin_map_id, sites=[0])
-        else:
-            self._pin_map_context = self._pin_map_context._replace(pin_map_id=pin_map_id)
+        self._pin_map_context = self._pin_map_context._replace(pin_map_id=pin_map_id)
 
 % if "from pathlib import Path" in built_in_import_modules:
 

--- a/packages/generator/tests/test_assets/example_renders/measurement_plugin_client/non_streaming_data_measurement_client.py
+++ b/packages/generator/tests/test_assets/example_renders/measurement_plugin_client/non_streaming_data_measurement_client.py
@@ -420,7 +420,7 @@ class NonStreamingDataMeasurementClient:
         if grpc_channel is not None:
             self._stub = v2_measurement_service_pb2_grpc.MeasurementServiceStub(grpc_channel)
         self._create_file_descriptor()
-        self._pin_map_context: Optional[PinMapContext] = None
+        self._pin_map_context: PinMapContext = PinMapContext(pin_map_id="", sites=[0])
 
     @property
     def pin_map_context(self) -> PinMapContext:
@@ -438,8 +438,7 @@ class NonStreamingDataMeasurementClient:
     @property
     def sites(self) -> List[int]:
         """The sites where the measurement must be executed."""
-        if self._pin_map_context is not None:
-            return self._pin_map_context.sites
+        return self._pin_map_context.sites
 
     @sites.setter
     def sites(self, val: List[int]) -> None:
@@ -510,7 +509,7 @@ class NonStreamingDataMeasurementClient:
         )
         return v2_measurement_service_pb2.MeasureRequest(
             configuration_parameters=serialized_configuration,
-            pin_map_context=self._pin_map_context._to_grpc() if self._pin_map_context else None,
+            pin_map_context=self._pin_map_context._to_grpc(),
         )
 
     def _deserialize_response(
@@ -667,10 +666,7 @@ class NonStreamingDataMeasurementClient:
             pin_map_path: Absolute path of the pin map file.
         """
         pin_map_id = self._get_pin_map_client().update_pin_map(pin_map_path)
-        if self._pin_map_context is None:
-            self._pin_map_context = PinMapContext(pin_map_id=pin_map_id, sites=[0])
-        else:
-            self._pin_map_context = self._pin_map_context._replace(pin_map_id=pin_map_id)
+        self._pin_map_context = self._pin_map_context._replace(pin_map_id=pin_map_id)
 
 
 def _convert_paths_to_strings(parameter_values: Iterable[Any]) -> List[Any]:

--- a/packages/generator/tests/test_assets/example_renders/measurement_plugin_client/void_measurement_client.py
+++ b/packages/generator/tests/test_assets/example_renders/measurement_plugin_client/void_measurement_client.py
@@ -73,7 +73,7 @@ class VoidMeasurementClient:
         if grpc_channel is not None:
             self._stub = v2_measurement_service_pb2_grpc.MeasurementServiceStub(grpc_channel)
         self._create_file_descriptor()
-        self._pin_map_context: Optional[PinMapContext] = None
+        self._pin_map_context: PinMapContext = PinMapContext(pin_map_id="", sites=[0])
 
     @property
     def pin_map_context(self) -> PinMapContext:
@@ -91,8 +91,7 @@ class VoidMeasurementClient:
     @property
     def sites(self) -> List[int]:
         """The sites where the measurement must be executed."""
-        if self._pin_map_context is not None:
-            return self._pin_map_context.sites
+        return self._pin_map_context.sites
 
     @sites.setter
     def sites(self, val: List[int]) -> None:
@@ -163,7 +162,7 @@ class VoidMeasurementClient:
         )
         return v2_measurement_service_pb2.MeasureRequest(
             configuration_parameters=serialized_configuration,
-            pin_map_context=self._pin_map_context._to_grpc() if self._pin_map_context else None,
+            pin_map_context=self._pin_map_context._to_grpc(),
         )
 
     def measure(self, integer_in: int = 10) -> None:
@@ -216,7 +215,4 @@ class VoidMeasurementClient:
             pin_map_path: Absolute path of the pin map file.
         """
         pin_map_id = self._get_pin_map_client().update_pin_map(pin_map_path)
-        if self._pin_map_context is None:
-            self._pin_map_context = PinMapContext(pin_map_id=pin_map_id, sites=[0])
-        else:
-            self._pin_map_context = self._pin_map_context._replace(pin_map_id=pin_map_id)
+        self._pin_map_context = self._pin_map_context._replace(pin_map_id=pin_map_id)


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Updated the Measurement Plug-In Client template to set a default value for the `PinMapContext.sites`.

### Why should this Pull Request be merged?

- When the measurement client is run for a pin-based measurement using IOResource name, sites value of the pin map context input should be explicitly set to 0.  If there are no sites in the pin map context, some measurement would fail with an exception.
**Context**: https://dev.azure.com/ni/DevCentral/_git/983dfe62-3b16-436f-b2ef-d98a72840b64/pullrequest/698395

### What testing has been done?

- Done manual testing.
- Existing and new automation tests passed.