### PR TITLE
examples: Don't assume array parameters are implemented as lists

### DIFF
--- a/examples/niscope_acquire_waveform/measurement.py
+++ b/examples/niscope_acquire_waveform/measurement.py
@@ -5,7 +5,7 @@ import pathlib
 import sys
 import threading
 import time
-from typing import List, Tuple
+from typing import List, Sequence, Tuple
 
 import click
 import grpc
@@ -64,7 +64,7 @@ measurement_service = nims.MeasurementService(
 @measurement_service.output("waveform2", nims.DataType.DoubleArray1D)
 @measurement_service.output("waveform3", nims.DataType.DoubleArray1D)
 def measure(
-    measurement_pins: List[str],
+    measurement_pins: Sequence[str],
     vertical_range: float,
     vertical_coupling: str,
     input_impedance: float,
@@ -90,7 +90,7 @@ def measure(
     measurement_service.context.add_cancel_callback(cancellation_event.set)
 
     with measurement_service.context.reserve_session(
-        measurement_pins + [trigger_pin]
+        list(measurement_pins) + [trigger_pin]
     ) as reservation:
         with reservation.initialize_niscope_session() as session_info:
             # Use connections to map pin names to channel names. This sets the

--- a/examples/sample_measurement/measurement.py
+++ b/examples/sample_measurement/measurement.py
@@ -4,7 +4,7 @@ import logging
 import pathlib
 import sys
 from enum import Enum
-from typing import Sequence, Tuple
+from typing import Iterable, Tuple
 
 import click
 import ni_measurement_plugin_sdk_service as nims
@@ -62,14 +62,14 @@ class Color(Enum):
 @measurement_service.output("String Array out", nims.DataType.StringArray1D)
 def measure(
     float_input: float,
-    double_array_input: Sequence[float],
+    double_array_input: Iterable[float],
     bool_input: bool,
     string_input: str,
     enum_input: Color,
     protobuf_enum_input: color_pb2.ProtobufColor.ValueType,
-    string_array_in: Sequence[str],
+    string_array_in: Iterable[str],
 ) -> Tuple[
-    float, Sequence[float], bool, str, Color, color_pb2.ProtobufColor.ValueType, Sequence[str]
+    float, Iterable[float], bool, str, Color, color_pb2.ProtobufColor.ValueType, Iterable[str]
 ]:
     """Perform a loopback measurement with various data types."""
     logging.info("Executing measurement")

--- a/examples/sample_measurement/measurement.py
+++ b/examples/sample_measurement/measurement.py
@@ -4,7 +4,7 @@ import logging
 import pathlib
 import sys
 from enum import Enum
-from typing import Iterable, Tuple
+from typing import Sequence, Tuple
 
 import click
 import ni_measurement_plugin_sdk_service as nims
@@ -62,14 +62,14 @@ class Color(Enum):
 @measurement_service.output("String Array out", nims.DataType.StringArray1D)
 def measure(
     float_input: float,
-    double_array_input: Iterable[float],
+    double_array_input: Sequence[float],
     bool_input: bool,
     string_input: str,
     enum_input: Color,
     protobuf_enum_input: color_pb2.ProtobufColor.ValueType,
-    string_array_in: Iterable[str],
+    string_array_in: Sequence[str],
 ) -> Tuple[
-    float, Iterable[float], bool, str, Color, color_pb2.ProtobufColor.ValueType, Iterable[str]
+    float, Sequence[float], bool, str, Color, color_pb2.ProtobufColor.ValueType, Sequence[str]
 ]:
     """Perform a loopback measurement with various data types."""
     logging.info("Executing measurement")

--- a/packages/service/tests/utilities/measurements/nidaqmx_measurement/__init__.py
+++ b/packages/service/tests/utilities/measurements/nidaqmx_measurement/__init__.py
@@ -1,7 +1,7 @@
 """NI-DAQmx measurement plug-in test service."""
 
 import pathlib
-from typing import List, Sequence, Tuple
+from typing import Iterable, List, Sequence, Tuple
 
 import nidaqmx
 
@@ -27,7 +27,7 @@ measurement_service = nims.MeasurementService(
 @measurement_service.output("connected_channels", nims.DataType.StringArray1D)
 @measurement_service.output("voltage_values", nims.DataType.DoubleArray1D)
 def measure(
-    pin_names: List[str],
+    pin_names: Iterable[str],
     multi_session: bool,
 ) -> Tuple[List[str], List[str], List[str], List[str], List[float]]:
     """NI-DAQmx measurement plug-in test service."""

--- a/packages/service/tests/utilities/measurements/nidcpower_measurement/__init__.py
+++ b/packages/service/tests/utilities/measurements/nidcpower_measurement/__init__.py
@@ -2,7 +2,7 @@
 
 import pathlib
 from contextlib import ExitStack
-from typing import Iterable, Sequence, Tuple
+from typing import Iterable, List, Sequence, Tuple
 
 import hightime
 import nidcpower
@@ -64,14 +64,14 @@ def measure(
                     [session_info.resource_name],
                     [session_info.channel_list],
                     [connection.channel_name],
-                    [list(voltage_measurements)[0]],
-                    [list(current_measurements)[0]],
+                    [voltage_measurements[0]],
+                    [current_measurements[0]],
                 )
 
 
 def _source_measure_dc_voltage(
     connections: Sequence[nims.session_management.TypedConnection[nidcpower.Session]],
-) -> Tuple[Iterable[float], Iterable[float]]:
+) -> Tuple[List[float], List[float]]:
     for connection in connections:
         channel = connection.session.channels[connection.channel_name]
         channel.source_mode = nidcpower.SourceMode.SINGLE_POINT

--- a/packages/service/tests/utilities/measurements/nidigital_measurement/__init__.py
+++ b/packages/service/tests/utilities/measurements/nidigital_measurement/__init__.py
@@ -2,7 +2,7 @@
 
 import pathlib
 from itertools import groupby
-from typing import Iterable, Sequence, Tuple, Union
+from typing import Iterable, Sequence, Tuple, Union, List
 
 import nidigital
 
@@ -35,7 +35,7 @@ def measure(
     pin_names: Iterable[str],
     multi_session: bool,
 ) -> Tuple[
-    Iterable[str], Iterable[str], Iterable[str], Iterable[str], Iterable[str], Iterable[str]
+    Iterable[str], Iterable[str], Iterable[str], Iterable[str], Iterable[int], Iterable[int]
 ]:
     """NI-Digital measurement plug-in test service."""
     if multi_session:
@@ -56,8 +56,8 @@ def measure(
                         ", ".join(conn.channel_name for conn in conns)
                         for conns in connections_by_session
                     ],
-                    list(passing_sites),
-                    list(failing_sites),
+                    passing_sites,
+                    failing_sites,
                 )
     else:
         with measurement_service.context.reserve_session(pin_names) as reservation:
@@ -78,7 +78,7 @@ def measure(
 
 def _burst_spi_pattern(
     session_infos: Sequence[TypedSessionInformation[nidigital.Session]],
-) -> Tuple:
+) -> Tuple[List[int], List[int]]:
     specifications_file_path = "Specifications.specs"
     levels_file_path = "PinLevels.digilevels"
     timing_file_path = "Timing.digitiming"

--- a/packages/service/tests/utilities/measurements/nidmm_measurement/__init__.py
+++ b/packages/service/tests/utilities/measurements/nidmm_measurement/__init__.py
@@ -2,7 +2,7 @@
 
 import math
 import pathlib
-from typing import List, Sequence, Tuple
+from typing import Iterable, List, Sequence, Tuple
 
 import nidmm
 
@@ -29,7 +29,7 @@ measurement_service = nims.MeasurementService(
 @measurement_service.output("signals_out_of_range", nims.DataType.BooleanArray1D)
 @measurement_service.output("absolute_resolutions", nims.DataType.DoubleArray1D)
 def measure(
-    pin_names: List[str],
+    pin_names: Iterable[str],
     multi_session: bool,
 ) -> Tuple[List[str], List[str], List[str], List[str], List[bool], List[float]]:
     """NI-DMM measurement plug-in test service."""

--- a/packages/service/tests/utilities/measurements/unknown_interface_measurement/__init__.py
+++ b/packages/service/tests/utilities/measurements/unknown_interface_measurement/__init__.py
@@ -1,6 +1,7 @@
 """Contains utility functions to test loopback measurement service. """
 
 import pathlib
+from typing import Tuple
 
 import ni_measurement_plugin_sdk_service as nims
 
@@ -17,8 +18,8 @@ measurement_service = nims.MeasurementService(
 @measurement_service.register_measurement
 @measurement_service.configuration("Float In", nims.DataType.Float, 0.06)
 @measurement_service.output("Float out", nims.DataType.Float)
-def measure(float_input):
+def measure(float_input: float) -> Tuple[float]:
     """Loopback measurement on the float input."""
     float_output = float_input
 
-    return float_output
+    return (float_output,)

--- a/packages/service/tests/utilities/measurements/v1_only_measurement/__init__.py
+++ b/packages/service/tests/utilities/measurements/v1_only_measurement/__init__.py
@@ -1,6 +1,7 @@
 """Contains utility functions to test loopback measurement service. """
 
 import pathlib
+from typing import Tuple
 
 import ni_measurement_plugin_sdk_service as nims
 
@@ -17,8 +18,8 @@ measurement_service = nims.MeasurementService(
 @measurement_service.register_measurement
 @measurement_service.configuration("Float In", nims.DataType.Float, 0.06)
 @measurement_service.output("Float out", nims.DataType.Float)
-def measure(float_input):
+def measure(float_input: float) -> Tuple[float]:
     """Loopback measurement on the float input."""
     float_output = float_input
 
-    return float_output
+    return (float_output,)

--- a/packages/service/tests/utilities/measurements/v2_only_measurement/__init__.py
+++ b/packages/service/tests/utilities/measurements/v2_only_measurement/__init__.py
@@ -1,6 +1,7 @@
 """Contains utility functions to test loopback measurement service. """
 
 import pathlib
+from typing import Tuple
 
 import ni_measurement_plugin_sdk_service as nims
 
@@ -17,8 +18,8 @@ measurement_service = nims.MeasurementService(
 @measurement_service.register_measurement
 @measurement_service.configuration("Float In", nims.DataType.Float, 0.06)
 @measurement_service.output("Float out", nims.DataType.Float)
-def measure(float_input):
+def measure(float_input: float) -> Tuple[float]:
     """Loopback measurement on the float input."""
     float_output = float_input
 
-    return float_output
+    return (float_output,)


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

`niscope_acquire_waveform`: 
- Explicitly convert `measurement_pins` to a `list` before concatenating it to another `list`. 
- Update the type hint to `Sequence[str]`. `Iterable[str]` is also okay.

service/tests:
- Change configuration parameter type hints from `List[T]` to `Iterable[T]`. `Sequence[T]` is also okay.
- Fix incorrect type hints and weird conversions in `nidcpower_measurement`
- Fix incorrect type hints in `nidigital_measurement`
- Fix some test services that didn't have type hints and were returning a float instead of a tuple

### Why should this Pull Request be merged?

After #767, array parameters are represented as a `protobuf`-specific `Sequence[T]` such as `RepeatedScalarFieldContainer[T]`.

### What testing has been done?

Ran updated examples.