### PR TITLE
[releases/2.1] Cherry-pick: generator: Fix SyntaxWarning caused by incorrect escape sequence

### DIFF
--- a/packages/generator/ni_measurement_plugin_sdk_generator/client/_support.py
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/client/_support.py
@@ -29,7 +29,7 @@ from ni_measurement_plugin_sdk_service.measurement.client_support import (
 
 _V2_MEASUREMENT_SERVICE_INTERFACE = "ni.measurementlink.measurement.v2.MeasurementService"
 
-_INVALID_CHARS = "`~!@#$%^&*()-+={}[]\|:;',<>.?/ \n"
+_INVALID_CHARS = "`~!@#$%^&*()-+={}[]\\|:;',<>.?/ \n"
 
 _XY_DATA_IMPORT = "from ni_measurement_plugin_sdk_service._internal.stubs.ni.protobuf.types.xydata_pb2 import DoubleXYData"
 _PATH_IMPORT = "from pathlib import Path"


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Cherry-pick https://github.com/ni/measurement-plugin-python/pull/932 into releases/2.1.