### PR TITLE
[releases/2.1] Cherry-pick: Update version checking to warn that version is deprecated and error if there is no .serviceconfig version

### DIFF
--- a/packages/service/ni_measurement_plugin_sdk_service/measurement/service.py
+++ b/packages/service/ni_measurement_plugin_sdk_service/measurement/service.py
@@ -218,7 +218,14 @@ class MeasurementService:
                 f"Service class '{service_class}' not found in '{service_config_file}'"
             )
 
+        if version:
+            warnings.warn(
+                "The 'version' constructor parameter is deprecated. Specify the version using the 'version' field in the .serviceconfig file instead.",
+                DeprecationWarning,
+            )
         config_version = service.get("version")
+        if version and config_version is None:
+            version = ""
         if config_version is not None:
             if version and version != config_version:
                 raise RuntimeError(

--- a/packages/service/tests/acceptance/test_measurement_service.py
+++ b/packages/service/tests/acceptance/test_measurement_service.py
@@ -253,7 +253,7 @@ def _validate_get_metadata_response(
     ]
 ):
     assert get_metadata_response.measurement_details.display_name == "Loopback Measurement (Py)"
-    assert get_metadata_response.measurement_details.version == "0.1.0.0"
+    assert get_metadata_response.measurement_details.version == "1.2.3.4"
 
     expected_version = "v1"
     if isinstance(get_metadata_response, v2_measurement_service_pb2.GetMetadataResponse):

--- a/packages/service/tests/assets/example.NoVersion.serviceconfig
+++ b/packages/service/tests/assets/example.NoVersion.serviceconfig
@@ -1,0 +1,19 @@
+{
+  "services": [
+    {
+      "displayName": "SampleMeasurement",
+      "serviceClass": "SampleMeasurement_Python",
+      "descriptionUrl": "https://www.example.com/SampleMeasurement.html",
+      "providedInterfaces": [
+        "ni.measurementlink.measurement.v1.MeasurementService",
+        "ni.measurementlink.measurement.v2.MeasurementService"
+      ],
+      "path": "start.bat",
+      "annotations": {
+        "ni/service.description": "Measure inrush current with a shorted load and validate results against configured limits.",
+        "ni/service.collection": "CurrentTests.Inrush",
+        "ni/service.tags": [ "powerup", "current" ]
+      }
+    }
+  ]
+}

--- a/packages/service/tests/assets/example.v1.serviceconfig
+++ b/packages/service/tests/assets/example.v1.serviceconfig
@@ -7,6 +7,7 @@
       "providedInterfaces": [
         "ni.measurementlink.measurement.v1.MeasurementService"
       ],
+      "version": "1.0.1",
       "path": "start.bat"
     }
   ]

--- a/packages/service/tests/unit/test_service.py
+++ b/packages/service/tests/unit/test_service.py
@@ -365,7 +365,7 @@ no_annotations: typing.Dict[str, str] = {}
         ),
         (
             "example.v1.serviceconfig",
-            "",
+            "1.0.1",
             ["ni.measurementlink.measurement.v1.MeasurementService"],
             no_annotations,
         ),
@@ -446,11 +446,22 @@ def test___service_config___create_measurement_service_with_version___version_di
     assert "Version mismatch" in str(version_error.value)
 
 
+def test___service_config___create_measurement_service_with_version___service_config_has_no_version(
+    test_assets_directory: pathlib.Path,
+):
+    measurement_service = MeasurementService(
+        service_config_path=test_assets_directory / "example.NoVersion.serviceconfig",
+        version="2.0.1",
+    )
+
+    assert not measurement_service.service_info.versions[0]
+
+
 @pytest.mark.parametrize(
     "service_config,version",
     [
         ("example.serviceconfig", "1.0.1"),
-        ("example.v1.serviceconfig", "2.0.1"),
+        ("example.v1.serviceconfig", "1.0.1"),
     ],
 )
 def test___service_config___create_measurement_service_with_version___version_is_used(

--- a/packages/service/tests/utilities/measurements/loopback_measurement/LoopbackMeasurement.serviceconfig
+++ b/packages/service/tests/utilities/measurements/loopback_measurement/LoopbackMeasurement.serviceconfig
@@ -8,6 +8,7 @@
         "ni.measurementlink.measurement.v1.MeasurementService",
         "ni.measurementlink.measurement.v2.MeasurementService"
       ],
+      "version": "1.2.3.4",
       "path": "start.bat",
       "annotations": {
         "ni/service.description": "Measurement plug-in test service that performs a loopback measurement with various data types.",

--- a/packages/service/tests/utilities/measurements/loopback_measurement/__init__.py
+++ b/packages/service/tests/utilities/measurements/loopback_measurement/__init__.py
@@ -20,7 +20,6 @@ class Color(Enum):
 service_directory = pathlib.Path(__file__).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "LoopbackMeasurement.serviceconfig",
-    version="0.1.0.0",
     ui_file_paths=[
         service_directory,
     ],

--- a/packages/service/tests/utilities/measurements/nidaqmx_measurement/__init__.py
+++ b/packages/service/tests/utilities/measurements/nidaqmx_measurement/__init__.py
@@ -11,7 +11,6 @@ from ni_measurement_plugin_sdk_service.session_management import TypedSessionInf
 service_directory = pathlib.Path(__file__).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "NIDAQmxMeasurement.serviceconfig",
-    version="0.1.0.0",
     ui_file_paths=[
         service_directory,
     ],

--- a/packages/service/tests/utilities/measurements/nidcpower_measurement/__init__.py
+++ b/packages/service/tests/utilities/measurements/nidcpower_measurement/__init__.py
@@ -12,7 +12,6 @@ import ni_measurement_plugin_sdk_service as nims
 service_directory = pathlib.Path(__file__).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "NIDCPowerMeasurement.serviceconfig",
-    version="0.1.0.0",
     ui_file_paths=[
         service_directory,
     ],

--- a/packages/service/tests/utilities/measurements/nidigital_measurement/__init__.py
+++ b/packages/service/tests/utilities/measurements/nidigital_measurement/__init__.py
@@ -15,7 +15,6 @@ from ni_measurement_plugin_sdk_service.session_management import (
 service_directory = pathlib.Path(__file__).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "NIDigitalMeasurement.serviceconfig",
-    version="0.1.0.0",
     ui_file_paths=[
         service_directory,
     ],

--- a/packages/service/tests/utilities/measurements/nidmm_measurement/__init__.py
+++ b/packages/service/tests/utilities/measurements/nidmm_measurement/__init__.py
@@ -12,7 +12,6 @@ from ni_measurement_plugin_sdk_service.session_management import TypedSessionInf
 service_directory = pathlib.Path(__file__).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "NIDmmMeasurement.serviceconfig",
-    version="0.1.0.0",
     ui_file_paths=[
         service_directory,
     ],

--- a/packages/service/tests/utilities/measurements/nifgen_measurement/__init__.py
+++ b/packages/service/tests/utilities/measurements/nifgen_measurement/__init__.py
@@ -12,7 +12,6 @@ from ni_measurement_plugin_sdk_service.session_management import TypedSessionInf
 service_directory = pathlib.Path(__file__).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "NIFgenMeasurement.serviceconfig",
-    version="0.1.0.0",
     ui_file_paths=[
         service_directory,
     ],

--- a/packages/service/tests/utilities/measurements/niscope_measurement/__init__.py
+++ b/packages/service/tests/utilities/measurements/niscope_measurement/__init__.py
@@ -12,7 +12,6 @@ from ni_measurement_plugin_sdk_service.session_management import TypedSessionInf
 service_directory = pathlib.Path(__file__).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "NIScopeMeasurement.serviceconfig",
-    version="0.1.0.0",
     ui_file_paths=[
         service_directory,
     ],

--- a/packages/service/tests/utilities/measurements/niswitch_measurement/__init__.py
+++ b/packages/service/tests/utilities/measurements/niswitch_measurement/__init__.py
@@ -11,7 +11,6 @@ from ni_measurement_plugin_sdk_service.session_management import TypedSessionInf
 service_directory = pathlib.Path(__file__).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "NISwitchMeasurement.serviceconfig",
-    version="0.1.0.0",
     ui_file_paths=[
         service_directory,
     ],

--- a/packages/service/tests/utilities/measurements/niswitch_multiplexer_measurement/__init__.py
+++ b/packages/service/tests/utilities/measurements/niswitch_multiplexer_measurement/__init__.py
@@ -11,7 +11,6 @@ from ni_measurement_plugin_sdk_service.session_management import TypedConnection
 service_directory = pathlib.Path(__file__).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "NISwitchMultiplexerMeasurement.serviceconfig",
-    version="0.1.0.0",
     ui_file_paths=[
         service_directory,
     ],

--- a/packages/service/tests/utilities/measurements/pin_aware_measurement/__init__.py
+++ b/packages/service/tests/utilities/measurements/pin_aware_measurement/__init__.py
@@ -8,7 +8,6 @@ import ni_measurement_plugin_sdk_service as nims
 service_directory = pathlib.Path(__file__).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "PinAwareMeasurement.serviceconfig",
-    version="0.1.0.0",
     ui_file_paths=[
         service_directory,
     ],

--- a/packages/service/tests/utilities/measurements/streaming_data_measurement/__init__.py
+++ b/packages/service/tests/utilities/measurements/streaming_data_measurement/__init__.py
@@ -12,7 +12,6 @@ import ni_measurement_plugin_sdk_service as nims
 service_directory = pathlib.Path(__file__).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "StreamingDataMeasurement.serviceconfig",
-    version="0.1.0.0",
     ui_file_paths=[
         service_directory,
     ],

--- a/packages/service/tests/utilities/measurements/unknown_interface_measurement/__init__.py
+++ b/packages/service/tests/utilities/measurements/unknown_interface_measurement/__init__.py
@@ -7,7 +7,6 @@ import ni_measurement_plugin_sdk_service as nims
 service_directory = pathlib.Path(__file__).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "unknown_interface.serviceconfig",
-    version="0.1.0.0",
     ui_file_paths=[
         service_directory,
     ],

--- a/packages/service/tests/utilities/measurements/v1_only_measurement/__init__.py
+++ b/packages/service/tests/utilities/measurements/v1_only_measurement/__init__.py
@@ -7,7 +7,6 @@ import ni_measurement_plugin_sdk_service as nims
 service_directory = pathlib.Path(__file__).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "v1_only.serviceconfig",
-    version="0.1.0.0",
     ui_file_paths=[
         service_directory,
     ],

--- a/packages/service/tests/utilities/measurements/v2_only_measurement/__init__.py
+++ b/packages/service/tests/utilities/measurements/v2_only_measurement/__init__.py
@@ -7,7 +7,6 @@ import ni_measurement_plugin_sdk_service as nims
 service_directory = pathlib.Path(__file__).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "v2_only.serviceconfig",
-    version="0.1.0.0",
     ui_file_paths=[
         service_directory,
     ],

--- a/packages/service/tests/utilities/measurements/yield_vs_return_measurement/__init__.py
+++ b/packages/service/tests/utilities/measurements/yield_vs_return_measurement/__init__.py
@@ -17,7 +17,6 @@ UI_UPDATE_INTERVAL_IN_SECONDS = 100e-3
 service_directory = pathlib.Path(__file__).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "UIProgressUpdates.serviceconfig",
-    version="0.5.0.0",
     ui_file_paths=[
         service_directory,
     ],


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Cherry-pick https://github.com/ni/measurement-plugin-python/pull/911 into releases/2.1.