### PR TITLE
[releases/2.1] Cherry-pick: Update Measurement Plug-In Generated Client to Resolve with the Corresponding Measurement Service Version 

### DIFF
--- a/packages/generator/ni_measurement_plugin_sdk_generator/client/__init__.py
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/client/__init__.py
@@ -88,6 +88,7 @@ def _create_client(
         directory_out=directory_out,
         class_name=class_name,
         display_name=metadata.measurement_details.display_name,
+        version=metadata.measurement_details.version,
         configuration_metadata=configuration_metadata,
         output_metadata=output_metadata,
         service_class=measurement_service_class,

--- a/packages/generator/ni_measurement_plugin_sdk_generator/client/templates/measurement_plugin_client.py.mako
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/client/templates/measurement_plugin_client.py.mako
@@ -3,7 +3,7 @@ import re
 from typing import Any
 %>\
 \
-<%page args="class_name, display_name, configuration_metadata, output_metadata, service_class, configuration_parameters_with_type_and_default_values, measure_api_parameters, output_parameters_with_type, built_in_import_modules, custom_import_modules, enum_by_class_name, configuration_parameters_type_url"/>\
+<%page args="class_name, display_name, version, configuration_metadata, output_metadata, service_class, configuration_parameters_with_type_and_default_values, measure_api_parameters, output_parameters_with_type, built_in_import_modules, custom_import_modules, enum_by_class_name, configuration_parameters_type_url"/>\
 \
 <%
     def _format_default_value(value: Any) -> Any:
@@ -107,6 +107,7 @@ class ${class_name}:
         """
         self._initialization_lock = threading.RLock()
         self._service_class = ${service_class | repr}
+        self._version = ${version | repr}
         self._grpc_channel_pool = grpc_channel_pool
         self._discovery_client = discovery_client
         self._pin_map_client = pin_map_client
@@ -188,6 +189,7 @@ class ${class_name}:
                     service_location = self._get_discovery_client().resolve_service(
                         provided_interface=_V2_MEASUREMENT_SERVICE_INTERFACE,
                         service_class=self._service_class,
+                        version=self._version,
                     )
                     channel = self._get_grpc_channel_pool().get_channel(service_location.insecure_address)
                     self._stub = v2_measurement_service_pb2_grpc.MeasurementServiceStub(channel)

--- a/packages/generator/poetry.lock
+++ b/packages/generator/poetry.lock
@@ -793,7 +793,7 @@ types-protobuf = ">=4.24"
 
 [[package]]
 name = "ni-measurement-plugin-sdk-service"
-version = "2.1.0-dev0"
+version = "2.1.0-dev2"
 description = "Measurement Plugin Support for Python"
 optional = false
 python-versions = "^3.8"

--- a/packages/generator/pyproject.toml
+++ b/packages/generator/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ni_measurement_plugin_sdk_generator"
-version = "2.1.0-dev1"
+version = "2.1.0-dev2"
 description = "Measurement Plugin Code Generator for Python"
 authors = ["NI <opensource@ni.com>"]
 readme = "README.md"

--- a/packages/generator/tests/test_assets/example_renders/measurement_plugin_client/non_streaming_data_measurement_client.py
+++ b/packages/generator/tests/test_assets/example_renders/measurement_plugin_client/non_streaming_data_measurement_client.py
@@ -95,6 +95,7 @@ class NonStreamingDataMeasurementClient:
         """
         self._initialization_lock = threading.RLock()
         self._service_class = "ni.tests.NonStreamingDataMeasurement_Python"
+        self._version = "0.1.0.0"
         self._grpc_channel_pool = grpc_channel_pool
         self._discovery_client = discovery_client
         self._pin_map_client = pin_map_client
@@ -458,6 +459,7 @@ class NonStreamingDataMeasurementClient:
                     service_location = self._get_discovery_client().resolve_service(
                         provided_interface=_V2_MEASUREMENT_SERVICE_INTERFACE,
                         service_class=self._service_class,
+                        version=self._version,
                     )
                     channel = self._get_grpc_channel_pool().get_channel(
                         service_location.insecure_address

--- a/packages/generator/tests/test_assets/example_renders/measurement_plugin_client/void_measurement_client.py
+++ b/packages/generator/tests/test_assets/example_renders/measurement_plugin_client/void_measurement_client.py
@@ -53,6 +53,7 @@ class VoidMeasurementClient:
         """
         self._initialization_lock = threading.RLock()
         self._service_class = "ni.tests.VoidMeasurement_Python"
+        self._version = "0.1.0.0"
         self._grpc_channel_pool = grpc_channel_pool
         self._discovery_client = discovery_client
         self._pin_map_client = pin_map_client
@@ -111,6 +112,7 @@ class VoidMeasurementClient:
                     service_location = self._get_discovery_client().resolve_service(
                         provided_interface=_V2_MEASUREMENT_SERVICE_INTERFACE,
                         service_class=self._service_class,
+                        version=self._version,
                     )
                     channel = self._get_grpc_channel_pool().get_channel(
                         service_location.insecure_address

--- a/packages/generator/tests/utilities/measurements/non_streaming_data_measurement/NonStreamingDataMeasurement.serviceconfig
+++ b/packages/generator/tests/utilities/measurements/non_streaming_data_measurement/NonStreamingDataMeasurement.serviceconfig
@@ -2,6 +2,7 @@
   "services": [
     {
       "displayName": "Non-Streaming Data Measurement (Py)",
+      "version": "0.1.0.0",
       "serviceClass": "ni.tests.NonStreamingDataMeasurement_Python",
       "descriptionUrl": "",
       "providedInterfaces": [

--- a/packages/generator/tests/utilities/measurements/non_streaming_data_measurement/__init__.py
+++ b/packages/generator/tests/utilities/measurements/non_streaming_data_measurement/__init__.py
@@ -13,7 +13,6 @@ from tests.utilities.measurements.non_streaming_data_measurement._stubs import c
 service_directory = Path(__file__).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "NonStreamingDataMeasurement.serviceconfig",
-    version="0.1.0.0",
     ui_file_paths=[
         service_directory,
     ],

--- a/packages/generator/tests/utilities/measurements/pin_aware_measurement/PinAwareMeasurement.serviceconfig
+++ b/packages/generator/tests/utilities/measurements/pin_aware_measurement/PinAwareMeasurement.serviceconfig
@@ -2,6 +2,7 @@
   "services": [
     {
       "displayName": "Pin Aware Measurement (Py)",
+      "version": "0.1.0.0",
       "serviceClass": "ni.tests.PinAwareMeasurement_Python",
       "descriptionUrl": "",
       "providedInterfaces": [

--- a/packages/generator/tests/utilities/measurements/pin_aware_measurement/__init__.py
+++ b/packages/generator/tests/utilities/measurements/pin_aware_measurement/__init__.py
@@ -8,7 +8,6 @@ import ni_measurement_plugin_sdk_service as nims
 service_directory = pathlib.Path(__file__).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "PinAwareMeasurement.serviceconfig",
-    version="0.1.0.0",
     ui_file_paths=[
         service_directory,
     ],

--- a/packages/generator/tests/utilities/measurements/streaming_data_measurement/StreamingDataMeasurement.serviceconfig
+++ b/packages/generator/tests/utilities/measurements/streaming_data_measurement/StreamingDataMeasurement.serviceconfig
@@ -2,6 +2,7 @@
   "services": [
     {
       "displayName": "Streaming Data Measurement (Py)",
+      "version": "0.1.0.0",
       "serviceClass": "ni.tests.StreamingDataMeasurement_Python",
       "descriptionUrl": "",
       "providedInterfaces": [

--- a/packages/generator/tests/utilities/measurements/streaming_data_measurement/__init__.py
+++ b/packages/generator/tests/utilities/measurements/streaming_data_measurement/__init__.py
@@ -11,7 +11,6 @@ import ni_measurement_plugin_sdk_service as nims
 service_directory = pathlib.Path(__file__).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "StreamingDataMeasurement.serviceconfig",
-    version="0.1.0.0",
     ui_file_paths=[
         service_directory,
     ],

--- a/packages/generator/tests/utilities/measurements/void_measurement/VoidMeasurement.serviceconfig
+++ b/packages/generator/tests/utilities/measurements/void_measurement/VoidMeasurement.serviceconfig
@@ -2,6 +2,7 @@
   "services": [
     {
       "displayName": "Void Measurement (Py)",
+      "version": "0.1.0.0",
       "serviceClass": "ni.tests.VoidMeasurement_Python",
       "descriptionUrl": "",
       "providedInterfaces": [

--- a/packages/generator/tests/utilities/measurements/void_measurement/__init__.py
+++ b/packages/generator/tests/utilities/measurements/void_measurement/__init__.py
@@ -11,7 +11,6 @@ import ni_measurement_plugin_sdk_service as nims
 service_directory = Path(__file__).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=service_directory / "VoidMeasurement.serviceconfig",
-    version="0.1.0.0",
     ui_file_paths=[
         service_directory,
     ],

--- a/packages/sdk/pyproject.toml
+++ b/packages/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ni_measurement_plugin_sdk"
-version = "2.1.0-dev1"
+version = "2.1.0-dev2"
 description = "Measurement Plugin SDK for Python"
 authors = ["NI <opensource@ni.com>"]
 readme = "README.md"

--- a/packages/service/ni_measurement_plugin_sdk_service/discovery/_client.py
+++ b/packages/service/ni_measurement_plugin_sdk_service/discovery/_client.py
@@ -206,7 +206,13 @@ class DiscoveryClient:
             _logger.exception("Error in unregistering with discovery service.")
             raise
 
-    def resolve_service(self, provided_interface: str, service_class: str = "") -> ServiceLocation:
+    def resolve_service(
+        self,
+        provided_interface: str,
+        service_class: str = "",
+        deployment_target: str = "",
+        version: str = "",
+    ) -> ServiceLocation:
         """Resolve the location of a service.
 
         Given a description of a service, returns information that can be used to establish
@@ -218,12 +224,18 @@ class DiscoveryClient:
             service_class: The service "class" that should be matched. If the value is not
                 specified and there is more than one matching service registered, an error
                 is returned.
+            deployment_target: The deployment target from which the service should be resolved.
+            version: The version of the service to resolve. If not specified, the latest version
+                will be resolved.
 
         Returns:
             The service location.
         """
         request = discovery_service_pb2.ResolveServiceRequest(
-            provided_interface=provided_interface, service_class=service_class
+            provided_interface=provided_interface,
+            service_class=service_class,
+            deployment_target=deployment_target,
+            version=version,
         )
 
         response = self._get_stub().ResolveService(request)

--- a/packages/service/pyproject.toml
+++ b/packages/service/pyproject.toml
@@ -7,7 +7,7 @@ extend_exclude = '.tox/,*_pb2_grpc.py,*_pb2_grpc.pyi,*_pb2.py,*_pb2.pyi,ni_measu
 
 [tool.poetry]
 name = "ni_measurement_plugin_sdk_service"
-version = "2.1.0-dev1"
+version = "2.1.0-dev2"
 description = "Measurement Plugin Support for Python"
 authors = ["NI <opensource@ni.com>"]
 readme = "README.md" # apply the repo readme to the package as well

--- a/packages/service/tests/unit/test_discovery_client.py
+++ b/packages/service/tests/unit/test_discovery_client.py
@@ -118,7 +118,7 @@ def test___service_registered___unregister_service___sends_request(
     assert unregistration_success_flag
 
 
-def test___service_registered___resolve_service___sends_request(
+def test___service_registered___resolve_service_without_version___sends_request(
     discovery_client: DiscoveryClient, discovery_service_stub: Mock
 ):
     discovery_service_stub.ResolveService.return_value = GrpcServiceLocation(
@@ -135,6 +135,29 @@ def test___service_registered___resolve_service___sends_request(
     request: ResolveServiceRequest = discovery_service_stub.ResolveService.call_args.args[0]
     assert _TEST_SERVICE_INFO.provided_interfaces[0] == request.provided_interface
     assert _TEST_SERVICE_INFO.service_class == request.service_class
+    _assert_service_location_equal(_TEST_SERVICE_LOCATION, service_location)
+
+
+def test___service_registered___resolve_service_with_version___sends_request(
+    discovery_client: DiscoveryClient, discovery_service_stub: Mock
+):
+    discovery_service_stub.ResolveService.return_value = GrpcServiceLocation(
+        location=_TEST_SERVICE_LOCATION.location,
+        insecure_port=_TEST_SERVICE_LOCATION.insecure_port,
+        ssl_authenticated_port=_TEST_SERVICE_LOCATION.ssl_authenticated_port,
+    )
+
+    service_location = discovery_client.resolve_service(
+        provided_interface=_TEST_SERVICE_INFO.provided_interfaces[0],
+        service_class=_TEST_SERVICE_INFO.service_class,
+        version=_TEST_SERVICE_INFO.versions[0],
+    )
+
+    discovery_service_stub.ResolveService.assert_called_once()
+    request: ResolveServiceRequest = discovery_service_stub.ResolveService.call_args.args[0]
+    assert _TEST_SERVICE_INFO.provided_interfaces[0] == request.provided_interface
+    assert _TEST_SERVICE_INFO.service_class == request.service_class
+    assert _TEST_SERVICE_INFO.versions[0] == request.version
     _assert_service_location_equal(_TEST_SERVICE_LOCATION, service_location)
 
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Cherry-pick #925  into releases/2.1.