### PR TITLE
[High Priority] Add resolve service with information API in the discovery client

### DIFF
--- a/packages/service/ni_measurement_plugin_sdk_service/_internal/discovery_client.py
+++ b/packages/service/ni_measurement_plugin_sdk_service/_internal/discovery_client.py
@@ -5,9 +5,12 @@ import warnings
 from deprecation import DeprecatedWarning
 
 from ni_measurement_plugin_sdk_service.discovery._client import DiscoveryClient
-from ni_measurement_plugin_sdk_service.discovery._types import ServiceLocation
+from ni_measurement_plugin_sdk_service.discovery._types import (
+    ServiceLocation,
+    ResolveServiceWithInformationResponse,
+)
 
-__all__ = ["DiscoveryClient", "ServiceLocation"]
+__all__ = ["DiscoveryClient", "ServiceLocation", "ResolveServiceWithInformationResponse"]
 
 warnings.warn(
     DeprecatedWarning(

--- a/packages/service/ni_measurement_plugin_sdk_service/discovery/__init__.py
+++ b/packages/service/ni_measurement_plugin_sdk_service/discovery/__init__.py
@@ -1,6 +1,9 @@
 """Public API for accessing the NI Discovery Service."""
 
 from ni_measurement_plugin_sdk_service.discovery._client import DiscoveryClient
-from ni_measurement_plugin_sdk_service.discovery._types import ServiceLocation
+from ni_measurement_plugin_sdk_service.discovery._types import (
+    ServiceLocation,
+    ResolveServiceWithInformationResponse,
+)
 
-__all__ = ["DiscoveryClient", "ServiceLocation"]
+__all__ = ["DiscoveryClient", "ServiceLocation", "ResolveServiceWithInformationResponse"]

--- a/packages/service/ni_measurement_plugin_sdk_service/discovery/_types.py
+++ b/packages/service/ni_measurement_plugin_sdk_service/discovery/_types.py
@@ -2,6 +2,8 @@
 
 import typing
 
+from ni_measurement_plugin_sdk_service.measurement.info import ServiceInfo
+
 
 class ServiceLocation(typing.NamedTuple):
     """Represents the location of a service."""
@@ -19,3 +21,10 @@ class ServiceLocation(typing.NamedTuple):
     def ssl_authenticated_address(self) -> str:
         """Get the service's SSL-authenticated address in the format host:port."""
         return f"{self.location}:{self.ssl_authenticated_port}"
+
+
+class ResolveServiceWithInformationResponse(typing.NamedTuple):
+    """Represents the location of a service along with its information."""
+
+    service_location: ServiceLocation
+    service_info: ServiceInfo

--- a/packages/service/tests/unit/test_discovery_client.py
+++ b/packages/service/tests/unit/test_discovery_client.py
@@ -23,6 +23,8 @@ from ni_measurement_plugin_sdk_service._internal.stubs.ni.measurementlink.discov
     RegisterServiceRequest,
     RegisterServiceResponse,
     ResolveServiceRequest,
+    ResolveServiceWithInformationRequest,
+    ResolveServiceWithInformationResponse,
     ServiceDescriptor as GrpcServiceDescriptor,
     ServiceLocation as GrpcServiceLocation,
     UnregisterServiceRequest,
@@ -395,6 +397,67 @@ def test___no_registered_measurements___enumerate_services___returns_empty_list(
     assert not available_measurements
 
 
+@pytest.mark.parametrize("programming_language", ["Python", "LabVIEW"])
+def test___service_registered___resolve_service_with_information___sends_request(
+    discovery_client: DiscoveryClient, discovery_service_stub: Mock, programming_language: str
+):
+    expected_service_info = copy.deepcopy(_TEST_SERVICE_INFO)
+    expected_service_info.annotations[SERVICE_PROGRAMMINGLANGUAGE_KEY] = programming_language
+    discovery_service_stub.ResolveServiceWithInformation.return_value = (
+        ResolveServiceWithInformationResponse(
+            service_location=GrpcServiceLocation(
+                location=_TEST_SERVICE_LOCATION.location,
+                insecure_port=_TEST_SERVICE_LOCATION.insecure_port,
+                ssl_authenticated_port=_TEST_SERVICE_LOCATION.ssl_authenticated_port,
+            ),
+            service_descriptor=GrpcServiceDescriptor(
+                display_name=expected_service_info.display_name,
+                description_url=expected_service_info.description_url,
+                provided_interfaces=expected_service_info.provided_interfaces,
+                annotations=expected_service_info.annotations,
+                service_class=expected_service_info.service_class,
+                versions=expected_service_info.versions,
+            ),
+        )
+    )
+
+    resolve_service_response = discovery_client.resolve_service_with_information(
+        provided_interface=_TEST_SERVICE_INFO.provided_interfaces[0],
+        service_class=_TEST_SERVICE_INFO.service_class,
+        version=_TEST_SERVICE_INFO.versions[0],
+    )
+
+    discovery_service_stub.ResolveServiceWithInformation.assert_called_once()
+    request: ResolveServiceWithInformationRequest = (
+        discovery_service_stub.ResolveServiceWithInformation.call_args.args[0]
+    )
+    assert _TEST_SERVICE_INFO.provided_interfaces[0] == request.provided_interface
+    assert _TEST_SERVICE_INFO.service_class == request.service_class
+    assert _TEST_SERVICE_INFO.versions[0] == request.version
+    _assert_service_location_equal(
+        _TEST_SERVICE_LOCATION, resolve_service_response.service_location
+    )
+    _assert_service_info_equal(expected_service_info, resolve_service_response.service_info)
+
+
+def test___service_not_registered___resolve_service_with_information___raises_not_found_error(
+    discovery_client: DiscoveryClient, discovery_service_stub: Mock
+):
+    discovery_service_stub.ResolveServiceWithInformation.side_effect = FakeRpcError(
+        grpc.StatusCode.NOT_FOUND, details="Service not found"
+    )
+
+    with pytest.raises(grpc.RpcError) as exc_info:
+        _ = discovery_client.resolve_service_with_information(
+            provided_interface=_TEST_SERVICE_INFO.provided_interfaces[0],
+            service_class=_TEST_SERVICE_INFO.service_class,
+            version=_TEST_SERVICE_INFO.versions[0],
+        )
+
+    discovery_service_stub.ResolveServiceWithInformation.assert_called_once()
+    assert exc_info.value.code() == grpc.StatusCode.NOT_FOUND
+
+
 @pytest.fixture(scope="module")
 def subprocess_popen_kwargs() -> Dict[str, Any]:
     kwargs: Dict[str, Any] = {}
@@ -423,6 +486,7 @@ def discovery_service_stub(mocker: MockerFixture) -> Mock:
     stub.UnregisterService = mocker.create_autospec(grpc.UnaryUnaryMultiCallable)
     stub.EnumerateServices = mocker.create_autospec(grpc.UnaryUnaryMultiCallable)
     stub.ResolveService = mocker.create_autospec(grpc.UnaryUnaryMultiCallable)
+    stub.ResolveServiceWithInformation = mocker.create_autospec(grpc.UnaryUnaryMultiCallable)
     return stub
 
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Added `resolve_service_with_information` API in the discovery client.
- Added unit tests for the `resolve_service_with_information` API.

### Why should this Pull Request be merged?

- The Measurement Plug-In Client generator lacks backward compatibility. (**Context** - [#946](https://github.com/ni/measurement-plugin-python/issues/946))
- This implementation contains the addition of `resolve_service_with_information` API, which will be used by the client generator to fetch the version of the measurement during client generation.

### What testing has been done?

- Existing and new unit tests passed.