### PR TITLE
[releases/2.1] Cherry-pick: [High Priority] Add resolve service with information API in the discovery client (#948)

### DIFF
--- a/packages/service/ni_measurement_plugin_sdk_service/discovery/_types.py
+++ b/packages/service/ni_measurement_plugin_sdk_service/discovery/_types.py
@@ -1,6 +1,12 @@
 """Data types for the NI Discovery Service."""
 
+from __future__ import annotations
+
 import typing
+
+from ni_measurement_plugin_sdk_service._internal.stubs.ni.measurementlink.discovery.v1 import (
+    discovery_service_pb2,
+)
 
 
 class ServiceLocation(typing.NamedTuple):
@@ -19,3 +25,11 @@ class ServiceLocation(typing.NamedTuple):
     def ssl_authenticated_address(self) -> str:
         """Get the service's SSL-authenticated address in the format host:port."""
         return f"{self.location}:{self.ssl_authenticated_port}"
+
+    @classmethod
+    def _from_grpc(cls, other: discovery_service_pb2.ServiceLocation) -> ServiceLocation:
+        return ServiceLocation(
+            location=other.location,
+            insecure_port=other.insecure_port,
+            ssl_authenticated_port=other.ssl_authenticated_port,
+        )

--- a/packages/service/ni_measurement_plugin_sdk_service/measurement/info.py
+++ b/packages/service/ni_measurement_plugin_sdk_service/measurement/info.py
@@ -6,6 +6,10 @@ import enum
 from pathlib import Path
 from typing import Dict, List, NamedTuple
 
+from ni_measurement_plugin_sdk_service._internal.stubs.ni.measurementlink.discovery.v1 import (
+    discovery_service_pb2,
+)
+
 
 class MeasurementInfo(NamedTuple):
     """A named tuple providing information about a measurement."""
@@ -64,6 +68,17 @@ class ServiceInfo(NamedTuple):
     versions: List[str] = []
     """The list of versions associated with this service in
      the form major.minor.build[.revision] (e.g. 1.0.0)."""
+
+    @classmethod
+    def _from_grpc(cls, other: discovery_service_pb2.ServiceDescriptor) -> ServiceInfo:
+        return ServiceInfo(
+            service_class=other.service_class,
+            description_url=other.description_url,
+            provided_interfaces=list(other.provided_interfaces),
+            annotations=dict(other.annotations),
+            display_name=other.display_name,
+            versions=list(other.versions),
+        )
 
 
 class TypeSpecialization(enum.Enum):


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Cherry-pick https://github.com/ni/measurement-plugin-python/pull/948 into releases/2.1.