### PR TITLE
docs: update the initialize_niswitch_multiplexer_session(s) APIs docstring

### DIFF
--- a/packages/service/ni_measurement_plugin_sdk_service/session_management/_reservation.py
+++ b/packages/service/ni_measurement_plugin_sdk_service/session_management/_reservation.py
@@ -435,7 +435,7 @@ class MultiplexerSessionContainer(_BaseSessionContainer):
         Args:
             topology: Specifies the switch topology. If this argument is not
                 specified, the default value is "Configured Topology", which you
-                may override by setting ``MEASUREMENT_PLUGIN_NISWITCH_TOPOLOGY`` in
+                may override by setting ``MEASUREMENT_PLUGIN_NISWITCH_MULTIPLEXER_TOPOLOGY`` in
                 the configuration file (``.env``).
 
             simulate: Enables or disables simulation of the switch module. If
@@ -498,7 +498,7 @@ class MultiplexerSessionContainer(_BaseSessionContainer):
         Args:
             topology: Specifies the switch topology. If this argument is not
                 specified, the default value is "Configured Topology", which you
-                may override by setting ``MEASUREMENT_PLUGIN_NISWITCH_TOPOLOGY`` in
+                may override by setting ``MEASUREMENT_PLUGIN_NISWITCH_MULTIPLEXER_TOPOLOGY`` in
                 the configuration file (``.env``).
 
             simulate: Enables or disables simulation of the switch module. If
@@ -2637,13 +2637,13 @@ class BaseReservation(_BaseSessionContainer):
         Args:
             topology: Specifies the switch topology. If this argument is not
                 specified, the default value is "Configured Topology", which you
-                may override by setting ``MEASUREMENT_PLUGIN_NISWITCH_TOPOLOGY`` in
+                may override by setting ``MEASUREMENT_PLUGIN_NISWITCH_MULTIPLEXER_TOPOLOGY`` in
                 the configuration file (``.env``).
 
             simulate: Enables or disables simulation of the switch module. If
                 this argument is not specified, the default value is ``False``,
                 which you may override by setting
-                ``MEASUREMENT_PLUGIN_NISWITCH_SIMULATE`` in the configuration file
+                ``MEASUREMENT_PLUGIN_NISWITCH_MULTIPLEXER_SIMULATE`` in the configuration file
                 (``.env``).
 
             reset_device: Specifies whether to reset the switch module during
@@ -2686,13 +2686,13 @@ class BaseReservation(_BaseSessionContainer):
         Args:
             topology: Specifies the switch topology. If this argument is not
                 specified, the default value is "Configured Topology", which you
-                may override by setting ``MEASUREMENT_PLUGIN_NISWITCH_TOPOLOGY`` in
+                may override by setting ``MEASUREMENT_PLUGIN_NISWITCH_MULTIPLEXER_TOPOLOGY`` in
                 the configuration file (``.env``).
 
             simulate: Enables or disables simulation of the switch module. If
                 this argument is not specified, the default value is ``False``,
                 which you may override by setting
-                ``MEASUREMENT_PLUGIN_NISWITCH_SIMULATE`` in the configuration file
+                ``MEASUREMENT_PLUGIN_NISWITCH_MULTIPLEXER_SIMULATE`` in the configuration file
                 (``.env``).
 
             reset_device: Specifies whether to reset the switch module during


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?
During the addition of the `initialize_niswitch_multiplexer_session(s)` APIs, I overlooked the documentation where the environment constant mistakenly pointed to the `NISWITCH` constant instead of the `NISWITCH_MULTIPLEXER` variant.

### Why should this Pull Request be merged?
Ensures the documentation of the APIs is true and correct.

### What testing has been done?
NA.