### PR TITLE
Provide unique module names for the generated measurement clients during multiple client generation

### DIFF
--- a/packages/generator/ni_measurement_plugin_sdk_generator/client/__init__.py
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/client/__init__.py
@@ -103,7 +103,7 @@ def _create_client(
     )
 
     print(
-        f"The measurement plug-in client for the service class '{measurement_service_class}' is created successfully."
+        f"The measurement plug-in client for the service class '{measurement_service_class}' is created successfully as '{module_name}.py'."
     )
 
 
@@ -117,7 +117,7 @@ def _create_all_clients(directory_out: Optional[str]) -> None:
 
     for service_class in measurement_service_classes:
         base_service_class = extract_base_service_class(service_class)
-        module_name = create_module_name(base_service_class)
+        module_name = create_module_name(base_service_class, directory_out_path)
         class_name = create_class_name(base_service_class)
         validate_identifier(module_name, "module")
         validate_identifier(class_name, "class")
@@ -159,7 +159,7 @@ def _create_clients_interactively() -> None:
         )
 
         base_service_class = extract_base_service_class(service_class)
-        default_module_name = create_module_name(base_service_class)
+        default_module_name = create_module_name(base_service_class, directory_out_path)
         module_name = click.prompt(
             "Enter a name for the Python client module, or press Enter to use the default name.",
             type=str,
@@ -198,7 +198,7 @@ def _create_clients(
     for service_class in measurement_service_classes:
         base_service_class = extract_base_service_class(service_class)
         if has_multiple_service_classes or module_name is None:
-            module_name = create_module_name(base_service_class)
+            module_name = create_module_name(base_service_class, directory_out_path)
         if has_multiple_service_classes or class_name is None:
             class_name = create_class_name(base_service_class)
         validate_identifier(module_name, "module")

--- a/packages/generator/ni_measurement_plugin_sdk_generator/client/__init__.py
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/client/__init__.py
@@ -103,7 +103,7 @@ def _create_client(
     )
 
     print(
-        f"The measurement plug-in client for the service class '{measurement_service_class}' is created successfully as '{module_name}.py'."
+        f"The measurement plug-in client for the service class '{measurement_service_class}' has been successfully created as '{module_name}.py'."
     )
 
 

--- a/packages/generator/ni_measurement_plugin_sdk_generator/client/__init__.py
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/client/__init__.py
@@ -111,13 +111,14 @@ def _create_all_clients(directory_out: Optional[str]) -> None:
     channel_pool = GrpcChannelPool()
     discovery_client = DiscoveryClient(grpc_channel_pool=channel_pool)
 
+    generated_modules: List[str] = []
     directory_out_path = resolve_output_directory(directory_out)
     measurement_service_classes, _ = get_all_registered_measurement_info(discovery_client)
     validate_measurement_service_classes(measurement_service_classes)
 
     for service_class in measurement_service_classes:
         base_service_class = extract_base_service_class(service_class)
-        module_name = create_module_name(base_service_class, directory_out_path)
+        module_name = create_module_name(base_service_class, generated_modules)
         class_name = create_class_name(base_service_class)
         validate_identifier(module_name, "module")
         validate_identifier(class_name, "class")
@@ -130,10 +131,12 @@ def _create_all_clients(directory_out: Optional[str]) -> None:
             class_name=class_name,
             directory_out=directory_out_path,
         )
+        generated_modules.append(module_name)
 
 
 def _create_clients_interactively() -> None:
     print("Creating the Python Measurement Plug-In Client in interactive mode...")
+    generated_modules: List[str] = []
     channel_pool = GrpcChannelPool()
     discovery_client = DiscoveryClient(grpc_channel_pool=channel_pool)
     directory_out_path = resolve_output_directory()
@@ -159,7 +162,7 @@ def _create_clients_interactively() -> None:
         )
 
         base_service_class = extract_base_service_class(service_class)
-        default_module_name = create_module_name(base_service_class, directory_out_path)
+        default_module_name = create_module_name(base_service_class, generated_modules)
         module_name = click.prompt(
             "Enter a name for the Python client module, or press Enter to use the default name.",
             type=str,
@@ -182,6 +185,7 @@ def _create_clients_interactively() -> None:
             class_name=class_name,
             directory_out=directory_out_path,
         )
+        generated_modules.append(module_name)
 
 
 def _create_clients(
@@ -190,6 +194,7 @@ def _create_clients(
     class_name: Optional[str],
     directory_out: Optional[str],
 ) -> None:
+    generated_modules: List[str] = []
     channel_pool = GrpcChannelPool()
     discovery_client = DiscoveryClient(grpc_channel_pool=channel_pool)
     directory_out_path = resolve_output_directory(directory_out)
@@ -198,7 +203,7 @@ def _create_clients(
     for service_class in measurement_service_classes:
         base_service_class = extract_base_service_class(service_class)
         if has_multiple_service_classes or module_name is None:
-            module_name = create_module_name(base_service_class, directory_out_path)
+            module_name = create_module_name(base_service_class, generated_modules)
         if has_multiple_service_classes or class_name is None:
             class_name = create_class_name(base_service_class)
         validate_identifier(module_name, "module")
@@ -212,6 +217,7 @@ def _create_clients(
             class_name=class_name,
             directory_out=directory_out_path,
         )
+        generated_modules.append(module_name)
 
 
 @click.command()

--- a/packages/generator/ni_measurement_plugin_sdk_generator/client/_support.py
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/client/_support.py
@@ -2,7 +2,6 @@
 
 import json
 import keyword
-import os
 import pathlib
 import re
 import sys
@@ -345,19 +344,17 @@ def extract_base_service_class(service_class: str) -> str:
     return base_service_class
 
 
-def create_module_name(base_service_class: str, directory: pathlib.Path) -> str:
-    """Creates a module name using base service class."""
+def create_module_name(base_service_class: str, generated_modules: List[str]) -> str:
+    """Creates a unique module name using the base service class."""
     base_module_name = _camel_to_snake_case(base_service_class) + "_client"
-    module_name_with_extension = f"{base_module_name}.py"
-    filepath = os.path.join(directory, module_name_with_extension)
-    counter = 1
+    module_name = base_module_name
+    counter = 2
 
-    while os.path.exists(filepath):
-        module_name_with_extension = f"{base_module_name}_{counter}.py"
-        filepath = os.path.join(directory, module_name_with_extension)
+    while module_name in generated_modules:
+        module_name = f"{base_module_name}{counter}"
         counter += 1
 
-    return os.path.splitext(module_name_with_extension)[0]
+    return module_name
 
 
 def create_class_name(base_service_class: str) -> str:

--- a/packages/generator/ni_measurement_plugin_sdk_generator/client/_support.py
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/client/_support.py
@@ -2,6 +2,7 @@
 
 import json
 import keyword
+import os
 import pathlib
 import re
 import sys
@@ -344,9 +345,19 @@ def extract_base_service_class(service_class: str) -> str:
     return base_service_class
 
 
-def create_module_name(base_service_class: str) -> str:
+def create_module_name(base_service_class: str, directory: pathlib.Path) -> str:
     """Creates a module name using base service class."""
-    return _camel_to_snake_case(base_service_class) + "_client"
+    base_module_name = _camel_to_snake_case(base_service_class) + "_client"
+    module_name_with_extension = f"{base_module_name}.py"
+    filepath = os.path.join(directory, module_name_with_extension)
+    counter = 1
+
+    while os.path.exists(filepath):
+        module_name_with_extension = f"{base_module_name}_{counter}.py"
+        filepath = os.path.join(directory, module_name_with_extension)
+        counter += 1
+
+    return os.path.splitext(module_name_with_extension)[0]
 
 
 def create_class_name(base_service_class: str) -> str:


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Provide unique module names for the generated measurement clients by appending a numerical suffix (_1, _2, etc.) to the name during multiple client generation and interactive mode.

### Why should this Pull Request be merged?

- When creating multiple clients, one Python measurement client for the service class `ni.examples.SampleMeasurement_Python` and one LabVIEW measurement client for `ni.examples.SampleMeasurement_LabVIEW` will both be framed with the module name `sample_measurement_client`, leading to file overwriting.
- In this implementation, we will be appending a numerical suffix to provide unique module name to mitigate the above case.

**Context** - [Bug 2894546](https://dev.azure.com/ni/DevCentral/_workitems/edit/2894546)

### What testing has been done?

- Existing test cases passed.
- Tested manually.