### PR TITLE
Remove check_nimg from publish_nims workflow

### DIFF
--- a/.github/workflows/Publish_NIMS.yml
+++ b/.github/workflows/Publish_NIMS.yml
@@ -16,9 +16,8 @@ jobs:
   check_nims:
     name: Check NIMS
     uses: ./.github/workflows/check_nims.yml
-  check_nimg:
-    name: Check NIMG
-    uses: ./.github/workflows/check_nimg.yml
+  # Don't run check_nimg.yml because the generator now depends
+  # on the service and may reference a package version that doesn't exist yet.
   # Don't run check_examples.yml because the examples may reference a
   # package version that doesn't exist yet.
   build:


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Allows publishing to proceed if the generator depends on a service package that is not published yet.

**NOTE:** I intend to cherry-pick this to main after.

### Why should this Pull Request be merged?

Removes check that won't ever pass the way our release process works.

### What testing has been done?

N/A We'll see on publish.