### PR TITLE
Remove requirement for check_nimg to run the unit tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,7 +21,7 @@ jobs:
   run_unit_tests:
     name: Run unit tests
     uses: ./.github/workflows/run_unit_tests.yml
-    needs: [check_nims, check_nimg]
+    needs: [check_nims]
   run_system_tests:
     name: Run system tests
     uses: ./.github/workflows/run_system_tests.yml


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Removes the need for check_nimg to pass before running the unit tests.

### Why should this Pull Request be merged?

We need the unit tests to run for the pre-publish steps even if check_nimg is failing.