### PR TITLE
GitHub: Auto-cancel PR builds when new changes are pushed

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -12,6 +12,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+
 jobs:
   run_ci:
     name: Run CI

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -8,6 +8,10 @@ on:
   workflow_call:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   run_ci:
     name: Run CI

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -12,7 +12,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-
 jobs:
   run_ci:
     name: Run CI


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Enable `concurrency.cancel-in-progress` for PR.yml, like @maxxboehme did in https://github.com/ni/grpc-device/pull/1104

### Why should this Pull Request be merged?

Minimize resource usage when pushing multiple changes.

### What testing has been done?

None, PR build