### PR TITLE
generator: Remove _NET suffix from service class base name

### DIFF
--- a/packages/generator/ni_measurement_plugin_sdk_generator/client/_support.py
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/client/_support.py
@@ -421,7 +421,7 @@ def _camel_to_snake_case(camel_case_string: str) -> str:
 
 
 def _remove_suffix(string: str) -> str:
-    suffixes = ["_Python", "_LabVIEW"]
+    suffixes = ["_Python", "_LabVIEW", "_NET"]
     for suffix in suffixes:
         if string.endswith(suffix):
             if sys.version_info >= (3, 9):


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Update the client generator to remove a `_NET` suffix from the service class name when generating the default module/class names.

### Why should this Pull Request be merged?

Fixes #975 

### What testing has been done?

```
(.venv) PS D:\dev\measurement-plugin-python\examples\client> ni-measurement-plugin-client-generator --all
...
The measurement plug-in client for the service class 'ni.examples.SampleMeasurement_NET' has been successfully created as 'sample_measurement_client.py'.
The measurement plug-in client for the service class 'ni.examples.SampleMeasurement_Python' has been successfully created as 'sample_measurement_client2.py'.
...
```