### PR TITLE
Handle unsupported message type errors in client generator

### DIFF
--- a/packages/generator/ni_measurement_plugin_sdk_generator/client/__init__.py
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/client/__init__.py
@@ -31,7 +31,7 @@ from ni_measurement_plugin_sdk_generator.client._support import (
 )
 
 
-CLIENT_CREATION_ERROR_MESSAGE = "The measurement plug-in client creation for the service class '{}' has failed. Possible reason(s): {}"
+_CLIENT_CREATION_ERROR_MESSAGE = "Client creation failed for '{}'. Possible reason(s): {}"
 
 
 def _render_template(template_name: str, **template_args: Any) -> bytes:
@@ -117,6 +117,7 @@ def _create_all_clients(directory_out: Optional[str]) -> None:
     discovery_client = DiscoveryClient(grpc_channel_pool=channel_pool)
 
     generated_modules: List[str] = []
+    errors: List[str] = []
     directory_out_path = resolve_output_directory(directory_out)
     measurement_service_classes, _ = get_all_registered_measurement_info(discovery_client)
     validate_measurement_service_classes(measurement_service_classes)
@@ -139,7 +140,10 @@ def _create_all_clients(directory_out: Optional[str]) -> None:
                 generated_modules=generated_modules,
             )
         except Exception as e:
-            click.echo(CLIENT_CREATION_ERROR_MESSAGE.format(service_class, e))
+            errors.append(_CLIENT_CREATION_ERROR_MESSAGE.format(service_class,e))
+
+    if errors:
+        raise click.ClickException(errors[0])
 
 
 def _create_clients_interactively() -> None:
@@ -196,7 +200,7 @@ def _create_clients_interactively() -> None:
                 generated_modules=generated_modules,
             )
         except Exception as e:
-            click.echo(CLIENT_CREATION_ERROR_MESSAGE.format(service_class, e))
+            click.echo(_CLIENT_CREATION_ERROR_MESSAGE.format(service_class, e))
 
 
 def _create_clients(

--- a/packages/generator/ni_measurement_plugin_sdk_generator/client/__init__.py
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/client/__init__.py
@@ -31,7 +31,7 @@ from ni_measurement_plugin_sdk_generator.client._support import (
 )
 
 
-CLIENT_CREATION_ERROR_MESSAGE = "The measurement plug-in client creation for the service class '{}' has been failed. Possible reason(s): {}"
+CLIENT_CREATION_ERROR_MESSAGE = "The measurement plug-in client creation for the service class '{}' has failed. Possible reason(s): {}"
 
 
 def _render_template(template_name: str, **template_args: Any) -> bytes:
@@ -138,7 +138,6 @@ def _create_all_clients(directory_out: Optional[str]) -> None:
             generated_modules.append(module_name)
         except Exception as e:
             click.echo(CLIENT_CREATION_ERROR_MESSAGE.format(service_class, e))
-            continue
 
 
 def _create_clients_interactively() -> None:
@@ -232,7 +231,6 @@ def _create_clients(
             generated_modules.append(module_name)
         except Exception as e:
             click.echo(CLIENT_CREATION_ERROR_MESSAGE.format(service_class, e))
-            continue
 
 
 @click.command()

--- a/packages/generator/ni_measurement_plugin_sdk_generator/client/__init__.py
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/client/__init__.py
@@ -142,8 +142,14 @@ def _create_all_clients(directory_out: Optional[str]) -> None:
         except Exception as e:
             errors.append(_CLIENT_CREATION_ERROR_MESSAGE.format(service_class, e))
 
-    if errors:
+    if len(errors) == 1:
         raise click.ClickException(errors[0])
+    elif len(errors) > 1:
+        raise click.ClickException(
+            "Client creation failed for multiple measurement plug-ins:\n\n{}".format(
+                "\n\n".join(errors)
+            )
+        )
 
 
 def _create_clients_interactively() -> None:

--- a/packages/generator/ni_measurement_plugin_sdk_generator/client/__init__.py
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/client/__init__.py
@@ -136,7 +136,7 @@ def _create_all_clients(directory_out: Optional[str]) -> None:
                 directory_out=directory_out_path,
             )
         except Exception as e:
-            click.echo(CLIENT_CREATION_ERROR_MESSAGE.format(service_class,e))
+            click.echo(CLIENT_CREATION_ERROR_MESSAGE.format(service_class, e))
             continue
         generated_modules.append(module_name)
 
@@ -194,7 +194,7 @@ def _create_clients_interactively() -> None:
                 directory_out=directory_out_path,
             )
         except Exception as e:
-            click.echo(CLIENT_CREATION_ERROR_MESSAGE.format(service_class,e))
+            click.echo(CLIENT_CREATION_ERROR_MESSAGE.format(service_class, e))
             break
         generated_modules.append(module_name)
 
@@ -217,7 +217,7 @@ def _create_clients(
             if has_multiple_service_classes or module_name is None:
                 module_name = create_module_name(base_service_class, generated_modules)
             if has_multiple_service_classes or class_name is None:
-                class_name = create_class_name(base_service_class)  
+                class_name = create_class_name(base_service_class)
             validate_identifier(module_name, "module")
             validate_identifier(class_name, "class")
 
@@ -230,7 +230,7 @@ def _create_clients(
                 directory_out=directory_out_path,
             )
         except Exception as e:
-            click.echo(CLIENT_CREATION_ERROR_MESSAGE.format(service_class,e))
+            click.echo(CLIENT_CREATION_ERROR_MESSAGE.format(service_class, e))
             continue
         generated_modules.append(module_name)
 

--- a/packages/generator/ni_measurement_plugin_sdk_generator/client/__init__.py
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/client/__init__.py
@@ -140,7 +140,7 @@ def _create_all_clients(directory_out: Optional[str]) -> None:
                 generated_modules=generated_modules,
             )
         except Exception as e:
-            errors.append(_CLIENT_CREATION_ERROR_MESSAGE.format(service_class,e))
+            errors.append(_CLIENT_CREATION_ERROR_MESSAGE.format(service_class, e))
 
     if errors:
         raise click.ClickException(errors[0])

--- a/packages/generator/ni_measurement_plugin_sdk_generator/client/__init__.py
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/client/__init__.py
@@ -31,6 +31,9 @@ from ni_measurement_plugin_sdk_generator.client._support import (
 )
 
 
+CLIENT_CREATION_ERROR_MESSAGE = "The measurement plug-in client creation for the service class '{}' has been failed. Possible reason(s): {}"
+
+
 def _render_template(template_name: str, **template_args: Any) -> bytes:
     file_path = str(pathlib.Path(__file__).parent / "templates" / template_name)
     template = Template(filename=file_path, input_encoding="utf-8", output_encoding="utf-8")
@@ -117,20 +120,24 @@ def _create_all_clients(directory_out: Optional[str]) -> None:
     validate_measurement_service_classes(measurement_service_classes)
 
     for service_class in measurement_service_classes:
-        base_service_class = extract_base_service_class(service_class)
-        module_name = create_module_name(base_service_class, generated_modules)
-        class_name = create_class_name(base_service_class)
-        validate_identifier(module_name, "module")
-        validate_identifier(class_name, "class")
+        try:
+            base_service_class = extract_base_service_class(service_class)
+            module_name = create_module_name(base_service_class, generated_modules)
+            class_name = create_class_name(base_service_class)
+            validate_identifier(module_name, "module")
+            validate_identifier(class_name, "class")
 
-        _create_client(
-            channel_pool=channel_pool,
-            discovery_client=discovery_client,
-            measurement_service_class=service_class,
-            module_name=module_name,
-            class_name=class_name,
-            directory_out=directory_out_path,
-        )
+            _create_client(
+                channel_pool=channel_pool,
+                discovery_client=discovery_client,
+                measurement_service_class=service_class,
+                module_name=module_name,
+                class_name=class_name,
+                directory_out=directory_out_path,
+            )
+        except Exception as e:
+            click.echo(CLIENT_CREATION_ERROR_MESSAGE.format(service_class,e))
+            continue
         generated_modules.append(module_name)
 
 
@@ -161,30 +168,34 @@ def _create_clients_interactively() -> None:
             int(selection), measurement_service_classes
         )
 
-        base_service_class = extract_base_service_class(service_class)
-        default_module_name = create_module_name(base_service_class, generated_modules)
-        module_name = click.prompt(
-            "Enter a name for the Python client module, or press Enter to use the default name.",
-            type=str,
-            default=default_module_name,
-        )
-        validate_identifier(module_name, "module")
-        default_class_name = create_class_name(base_service_class)
-        class_name = click.prompt(
-            "Enter a name for the Python client class, or press Enter to use the default name.",
-            type=str,
-            default=default_class_name,
-        )
-        validate_identifier(class_name, "class")
+        try:
+            base_service_class = extract_base_service_class(service_class)
+            default_module_name = create_module_name(base_service_class, generated_modules)
+            module_name = click.prompt(
+                "Enter a name for the Python client module, or press Enter to use the default name.",
+                type=str,
+                default=default_module_name,
+            )
+            validate_identifier(module_name, "module")
+            default_class_name = create_class_name(base_service_class)
+            class_name = click.prompt(
+                "Enter a name for the Python client class, or press Enter to use the default name.",
+                type=str,
+                default=default_class_name,
+            )
+            validate_identifier(class_name, "class")
 
-        _create_client(
-            channel_pool=channel_pool,
-            discovery_client=discovery_client,
-            measurement_service_class=service_class,
-            module_name=module_name,
-            class_name=class_name,
-            directory_out=directory_out_path,
-        )
+            _create_client(
+                channel_pool=channel_pool,
+                discovery_client=discovery_client,
+                measurement_service_class=service_class,
+                module_name=module_name,
+                class_name=class_name,
+                directory_out=directory_out_path,
+            )
+        except Exception as e:
+            click.echo(CLIENT_CREATION_ERROR_MESSAGE.format(service_class,e))
+            break
         generated_modules.append(module_name)
 
 
@@ -201,22 +212,26 @@ def _create_clients(
 
     has_multiple_service_classes = len(measurement_service_classes) > 1
     for service_class in measurement_service_classes:
-        base_service_class = extract_base_service_class(service_class)
-        if has_multiple_service_classes or module_name is None:
-            module_name = create_module_name(base_service_class, generated_modules)
-        if has_multiple_service_classes or class_name is None:
-            class_name = create_class_name(base_service_class)
-        validate_identifier(module_name, "module")
-        validate_identifier(class_name, "class")
+        try:
+            base_service_class = extract_base_service_class(service_class)
+            if has_multiple_service_classes or module_name is None:
+                module_name = create_module_name(base_service_class, generated_modules)
+            if has_multiple_service_classes or class_name is None:
+                class_name = create_class_name(base_service_class)  
+            validate_identifier(module_name, "module")
+            validate_identifier(class_name, "class")
 
-        _create_client(
-            channel_pool=channel_pool,
-            discovery_client=discovery_client,
-            measurement_service_class=service_class,
-            module_name=module_name,
-            class_name=class_name,
-            directory_out=directory_out_path,
-        )
+            _create_client(
+                channel_pool=channel_pool,
+                discovery_client=discovery_client,
+                measurement_service_class=service_class,
+                module_name=module_name,
+                class_name=class_name,
+                directory_out=directory_out_path,
+            )
+        except Exception as e:
+            click.echo(CLIENT_CREATION_ERROR_MESSAGE.format(service_class,e))
+            continue
         generated_modules.append(module_name)
 
 

--- a/packages/generator/ni_measurement_plugin_sdk_generator/client/__init__.py
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/client/__init__.py
@@ -135,10 +135,10 @@ def _create_all_clients(directory_out: Optional[str]) -> None:
                 class_name=class_name,
                 directory_out=directory_out_path,
             )
+            generated_modules.append(module_name)
         except Exception as e:
             click.echo(CLIENT_CREATION_ERROR_MESSAGE.format(service_class, e))
             continue
-        generated_modules.append(module_name)
 
 
 def _create_clients_interactively() -> None:
@@ -193,10 +193,10 @@ def _create_clients_interactively() -> None:
                 class_name=class_name,
                 directory_out=directory_out_path,
             )
+            generated_modules.append(module_name)
         except Exception as e:
             click.echo(CLIENT_CREATION_ERROR_MESSAGE.format(service_class, e))
             break
-        generated_modules.append(module_name)
 
 
 def _create_clients(
@@ -229,10 +229,10 @@ def _create_clients(
                 class_name=class_name,
                 directory_out=directory_out_path,
             )
+            generated_modules.append(module_name)
         except Exception as e:
             click.echo(CLIENT_CREATION_ERROR_MESSAGE.format(service_class, e))
             continue
-        generated_modules.append(module_name)
 
 
 @click.command()

--- a/packages/generator/ni_measurement_plugin_sdk_generator/client/_support.py
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/client/_support.py
@@ -125,7 +125,7 @@ def get_configuration_and_output_metadata_by_index(
     for configuration in metadata.measurement_signature.configuration_parameters:
         if configuration.message_type:
             raise click.ClickException(
-                "Measurement configurations with message datatype are not supported."
+                f"Measurement configurations do not support message data types ({configuration.message_type} is unsupported)."
             )
 
         annotations_dict = dict(configuration.annotations.items())
@@ -155,7 +155,7 @@ def get_configuration_and_output_metadata_by_index(
     for output in metadata.measurement_signature.outputs:
         if output.message_type and output.message_type != "ni.protobuf.types.DoubleXYData":
             raise click.ClickException(
-                "Measurement outputs with message datatype other than DoubleXYData are not supported."
+                f"Measurement outputs do not support {output.message_type}. Only DoubleXYData is supported."
             )
 
         annotations_dict = dict(output.annotations.items())

--- a/packages/generator/ni_measurement_plugin_sdk_generator/client/_support.py
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/client/_support.py
@@ -325,46 +325,43 @@ def resolve_output_directory(directory_out: Optional[str] = None) -> pathlib.Pat
     return directory_out_path
 
 
-def validate_identifier(name: str, name_type: str) -> None:
-    """Validates whether the given string is a valid Python identifier."""
-    if not _is_python_identifier(name):
-        raise click.ClickException(
-            f"The {name_type} name '{name}' is not a valid Python identifier."
+def get_module_name(
+    service_class: str,
+    generated_modules: List[str],
+    is_interactive_mode: bool = False,
+) -> str:
+    """Creates a unique module name using the service class."""
+    base_service_class = _extract_base_service_class(service_class)
+    module_name = _create_module_name(base_service_class, generated_modules)
+
+    if is_interactive_mode:
+        module_name = click.prompt(
+            "Enter a name for the Python client module, or press Enter to use the default name.",
+            type=str,
+            default=module_name,
         )
-
-
-def extract_base_service_class(service_class: str) -> str:
-    """Creates a base service class from the measurement service class."""
-    base_service_class = service_class.split(".")[-1]
-    base_service_class = _remove_suffix(base_service_class)
-
-    if not base_service_class.isidentifier():
-        raise click.ClickException(
-            f"Client creation failed for '{service_class}'.\nEither provide a module name or update the measurement with a valid service class."
-        )
-    if not any(ch.isupper() for ch in base_service_class):
-        print(
-            f"Warning: The service class '{service_class}' does not adhere to the recommended format."
-        )
-    return base_service_class
-
-
-def create_module_name(base_service_class: str, generated_modules: List[str]) -> str:
-    """Creates a unique module name using the base service class."""
-    base_module_name = _camel_to_snake_case(base_service_class) + "_client"
-    module_name = base_module_name
-    counter = 2
-
-    while module_name in generated_modules:
-        module_name = f"{base_module_name}{counter}"
-        counter += 1
+    _validate_identifier(module_name, "module")
 
     return module_name
 
 
-def create_class_name(base_service_class: str) -> str:
-    """Creates a class name using base service class."""
-    return base_service_class.replace("_", "") + "Client"
+def get_class_name(
+    service_class: str,
+    is_interactive_mode: bool = False,
+) -> str:
+    """Creates a class name using service class."""
+    base_service_class = _extract_base_service_class(service_class)
+    class_name = _create_class_name(base_service_class)
+
+    if is_interactive_mode:
+        class_name = click.prompt(
+            "Enter a name for the Python client class, or press Enter to use the default name.",
+            type=str,
+            default=class_name,
+        )
+    _validate_identifier(class_name, "class")
+
+    return class_name
 
 
 def get_selected_measurement_service_class(
@@ -492,3 +489,41 @@ def _validate_and_transform_enum_annotations(enum_annotations: str) -> str:
         transformed_enum_annotations[enum_value] = value
 
     return json.dumps(transformed_enum_annotations)
+
+
+def _create_module_name(base_service_class: str, generated_modules: List[str]) -> str:
+    base_module_name = _camel_to_snake_case(base_service_class) + "_client"
+    module_name = base_module_name
+    counter = 2
+
+    while module_name in generated_modules:
+        module_name = f"{base_module_name}{counter}"
+        counter += 1
+
+    return module_name
+
+
+def _create_class_name(base_service_class: str) -> str:
+    return base_service_class.replace("_", "") + "Client"
+
+
+def _validate_identifier(name: str, name_type: str) -> None:
+    if not _is_python_identifier(name):
+        raise click.ClickException(
+            f"The {name_type} name '{name}' is not a valid Python identifier."
+        )
+
+
+def _extract_base_service_class(service_class: str) -> str:
+    base_service_class = service_class.split(".")[-1]
+    base_service_class = _remove_suffix(base_service_class)
+
+    if not base_service_class.isidentifier():
+        raise click.ClickException(
+            f"Client creation failed for '{service_class}'.\nEither provide a module name or update the measurement with a valid service class."
+        )
+    if not any(ch.isupper() for ch in base_service_class):
+        print(
+            f"Warning: The service class '{service_class}' does not adhere to the recommended format."
+        )
+    return base_service_class

--- a/packages/generator/ni_measurement_plugin_sdk_generator/client/_support.py
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/client/_support.py
@@ -127,7 +127,7 @@ def get_configuration_and_output_metadata_by_index(
             raise click.ClickException(
                 "Measurement configurations with message datatype are not supported."
             )
-        
+
         annotations_dict = dict(configuration.annotations.items())
         if _is_enum_param(configuration.type):
             annotations_dict["ni/enum.values"] = _validate_and_transform_enum_annotations(
@@ -153,11 +153,11 @@ def get_configuration_and_output_metadata_by_index(
 
     output_parameter_list = []
     for output in metadata.measurement_signature.outputs:
-        if output.message_type and output.message_type is not "ni.protobuf.types.DoubleXYData":
+        if output.message_type and output.message_type != "ni.protobuf.types.DoubleXYData":
             raise click.ClickException(
                 "Measurement outputs with message datatype other than DoubleXYData are not supported."
             )
-        
+
         annotations_dict = dict(output.annotations.items())
         if _is_enum_param(output.type):
             annotations_dict["ni/enum.values"] = _validate_and_transform_enum_annotations(


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Updated the client generator to raise a click exception for unsupported datatypes, by validating the message type after getting the metadata.
- Added `try-except` block to catch the exceptions raised during the creation of multiple clients and for all registered measurements. Also, show warning message about client creation failure and continue client creation for subsequent measurements.

### Why should this Pull Request be merged?

- This implementation fixes the following issues,
    - #974 
    - #906 

### What testing has been done?

- Done manual testing
- Existing automation test passed