### PR TITLE
Update package versions and update sdk to use file paths rather than PyPI

### DIFF
--- a/packages/generator/poetry.lock
+++ b/packages/generator/poetry.lock
@@ -802,7 +802,7 @@ types-protobuf = ">=4.24"
 
 [[package]]
 name = "ni-measurement-plugin-sdk-service"
-version = "2.1.0-dev2"
+version = "2.2.0-dev0"
 description = "Measurement Plug-In Support for Python"
 optional = false
 python-versions = "^3.8"
@@ -1362,4 +1362,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "af67807bad5aae7bc14c438be5c084ebd2a151e2ca336c7b4de388f17e6235d9"
+content-hash = "7f6cf4fdb19dafb63e32ad873fc767ef77d64600b9cd831a1d7a4df8f4722da5"

--- a/packages/generator/pyproject.toml
+++ b/packages/generator/pyproject.toml
@@ -26,7 +26,7 @@ grpcio = "^1.49.1"
 protobuf = "^4.21"
 black = ">=24.8.0"
 click-option-group = ">=0.5.6"
-ni-measurement-plugin-sdk-service = {version = "^2.1.0-dev1", allow-prereleases = true}
+ni-measurement-plugin-sdk-service = {version = "^2.1.0"}
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=7.2.0"

--- a/packages/generator/pyproject.toml
+++ b/packages/generator/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ni_measurement_plugin_sdk_generator"
-version = "2.1.0-dev2"
+version = "2.2.0-dev0"
 description = "Measurement Plug-In Code Generator for Python"
 authors = ["NI <opensource@ni.com>"]
 readme = "README.md"

--- a/packages/generator/pyproject.toml
+++ b/packages/generator/pyproject.toml
@@ -36,7 +36,8 @@ mypy = ">=1.0"
 mypy-protobuf = ">=3.4"
 types-protobuf = "^4.21"
 grpc-stubs = "^1.53"
-# Uncomment to use prerelease dependencies.
+# During development, use file paths to reference the latest source for packages
+# in the same Git repository.
 ni-measurement-plugin-sdk-service = {path = "../../packages/service", develop = true}
 bandit = { version = ">=1.7", extras = ["toml"] }
 tox = ">=4.0"

--- a/packages/sdk/poetry.lock
+++ b/packages/sdk/poetry.lock
@@ -272,39 +272,39 @@ files = [
 
 [[package]]
 name = "ni-measurement-plugin-sdk-generator"
-version = "2.1.0"
+version = "2.2.0-dev0"
 description = "Measurement Plug-In Code Generator for Python"
 optional = false
-python-versions = "<4.0,>=3.8"
-files = [
-    {file = "ni_measurement_plugin_sdk_generator-2.1.0-py3-none-any.whl", hash = "sha256:67bc4cc5a4c0dac41d49d9082673fcf4204f5c4bc07745508ac906418286f744"},
-    {file = "ni_measurement_plugin_sdk_generator-2.1.0.tar.gz", hash = "sha256:7686d3b1b9cfc5105321632db56e86a2979055fbb7e315e13830ef0e18eb0962"},
-]
+python-versions = "^3.8"
+files = []
+develop = true
 
 [package.dependencies]
 black = ">=24.8.0"
 click = ">=8.1.3"
 click-option-group = ">=0.5.6"
-grpcio = ">=1.49.1,<2.0.0"
-Mako = ">=1.2.1,<2.0.0"
-ni-measurement-plugin-sdk-service = ">=2.1.0,<3.0.0"
-protobuf = ">=4.21,<5.0"
+grpcio = "^1.49.1"
+Mako = "^1.2.1"
+ni-measurement-plugin-sdk-service = "^2.1.0"
+protobuf = "^4.21"
+
+[package.source]
+type = "directory"
+url = "../generator"
 
 [[package]]
 name = "ni-measurement-plugin-sdk-service"
-version = "2.1.0"
+version = "2.2.0-dev0"
 description = "Measurement Plug-In Support for Python"
 optional = false
-python-versions = "<4.0,>=3.8"
-files = [
-    {file = "ni_measurement_plugin_sdk_service-2.1.0-py3-none-any.whl", hash = "sha256:0cba7e1be8718aeefa24d1ccc33e521e9c03f2021e3c58a12aad87c078e57754"},
-    {file = "ni_measurement_plugin_sdk_service-2.1.0.tar.gz", hash = "sha256:0fc9edac12d19b90f295f3c60b620eaf467625ce7cbb5779de218e543e9d970a"},
-]
+python-versions = "^3.8"
+files = []
+develop = true
 
 [package.dependencies]
 deprecation = ">=2.1"
-grpcio = ">=1.49.1,<2.0.0"
-protobuf = ">=4.21,<5.0"
+grpcio = "^1.49.1"
+protobuf = "^4.21"
 python-decouple = ">=3.8"
 pywin32 = {version = ">=303", markers = "sys_platform == \"win32\""}
 traceloggingdynamic = {version = ">=1.0", markers = "python_version >= \"3.9\" and python_version < \"4.0\" and sys_platform == \"win32\""}
@@ -318,6 +318,10 @@ nidmm = ["nidmm[grpc] (>=1.4.4)"]
 nifgen = ["nifgen[grpc] (>=1.4.4)"]
 niscope = ["niscope[grpc] (>=1.4.4)"]
 niswitch = ["niswitch[grpc] (>=1.4.4)"]
+
+[package.source]
+type = "directory"
+url = "../service"
 
 [[package]]
 name = "packaging"
@@ -450,4 +454,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "655153d0bf52074b6481de5c5aca23a22ce0f88220643ed4448ce7c086a18eb9"
+content-hash = "9f4bd46b62519d49d8b94ed65a50b259c5a89567266c6ea1a01a9bf11bdff33c"

--- a/packages/sdk/pyproject.toml
+++ b/packages/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ni_measurement_plugin_sdk"
-version = "2.1.0-dev2"
+version = "2.2.0-dev0"
 description = "Measurement Plug-In SDK for Python"
 authors = ["NI <opensource@ni.com>"]
 readme = "README.md"

--- a/packages/sdk/pyproject.toml
+++ b/packages/sdk/pyproject.toml
@@ -24,7 +24,8 @@ ni-measurement-plugin-sdk-service = "*"
 ni-measurement-plugin-sdk-generator = "*"
 
 [tool.poetry.group.dev.dependencies]
-# Uncomment to use prerelease dependencies.
+# During development, use file paths to reference the latest source for packages
+# in the same Git repository.
 ni-measurement-plugin-sdk-service = {path = "../../packages/service", develop = true}
 ni-measurement-plugin-sdk-generator = {path = "../../packages/generator", develop = true}
 

--- a/packages/sdk/pyproject.toml
+++ b/packages/sdk/pyproject.toml
@@ -23,6 +23,11 @@ python = "^3.8"
 ni-measurement-plugin-sdk-service = "*"
 ni-measurement-plugin-sdk-generator = "*"
 
+[tool.poetry.group.dev.dependencies]
+# Uncomment to use prerelease dependencies.
+ni-measurement-plugin-sdk-service = {path = "../../packages/service", develop = true}
+ni-measurement-plugin-sdk-generator = {path = "../../packages/generator", develop = true}
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/packages/service/pyproject.toml
+++ b/packages/service/pyproject.toml
@@ -7,7 +7,7 @@ extend_exclude = '.tox/,*_pb2_grpc.py,*_pb2_grpc.pyi,*_pb2.py,*_pb2.pyi,ni_measu
 
 [tool.poetry]
 name = "ni_measurement_plugin_sdk_service"
-version = "2.1.0-dev2"
+version = "2.2.0-dev0"
 description = "Measurement Plug-In Support for Python"
 authors = ["NI <opensource@ni.com>"]
 readme = "README.md" # apply the repo readme to the package as well


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Change the `ni-measurement-plugin-sdk` package to use file paths to depend on `ni-measurement-plugin-sdk-generator ` and `ni-measurement-plugin-sdk-service` during PR/CI builds. This will prevent storing PyPI links to the generator/service packages in the sdk package's `poetry.lock` file.

Update `ni-measurement-plugin-sdk-generator ` to depend on the 2.1.0 released version of `ni-measurement-plugin-sdk-service`.

Update all of the the version numbers to 2.2.0-dev0.

### Why should this Pull Request be merged?

Attempt to resolve the problems that led to this weird version update: https://github.com/ni/measurement-plugin-python/pull/981

### What testing has been done?

PR build