### PR TITLE
generator: Add --verbose option to client generator

### DIFF
--- a/packages/generator/ni_measurement_plugin_sdk_generator/client/__init__.py
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/client/__init__.py
@@ -1,5 +1,6 @@
 """Utilizes command line args to create a Measurement Plug-In Client using template files."""
 
+import logging
 import pathlib
 from enum import Enum
 from typing import Any, Dict, List, Optional, Type
@@ -263,6 +264,12 @@ def _create_clients(
     "--directory-out",
     help="Output directory for Measurement Plug-In Client files. Default: '<current_directory>/<module_name>'",
 )
+@click.option(
+    "-v",
+    "--verbose",
+    count=True,
+    help="Enable verbose logging. Repeat to increase verbosity.",
+)
 def create_client(
     measurement_service_class: List[str],
     all: bool,
@@ -270,11 +277,20 @@ def create_client(
     module_name: Optional[str],
     class_name: Optional[str],
     directory_out: Optional[str],
+    verbose: int,
 ) -> None:
     """Generates a Python Measurement Plug-In Client module for the measurement service.
 
     You can use the generated module to interact with the corresponding measurement service.
     """
+    if verbose > 1:
+        level = logging.DEBUG
+    elif verbose == 1:
+        level = logging.INFO
+    else:
+        level = logging.WARNING
+    logging.basicConfig(format="%(asctime)s %(levelname)s: %(message)s", level=level)
+
     if all:
         _create_all_clients(directory_out)
     elif interactive:

--- a/packages/generator/ni_measurement_plugin_sdk_generator/plugin/__init__.py
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/plugin/__init__.py
@@ -145,7 +145,7 @@ def create_measurement(
     description: str,
     collection: str,
     tags: Tuple[str, ...],
-    verbose: bool,
+    verbose: int,
 ) -> None:
     """Generate a Python measurement service from a template.
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Add `--verbose` option to client generator.

Fix a type hint in plugin generator.

### Why should this Pull Request be merged?

Fixes #976 

### What testing has been done?

Ran client generator with `-vv`, `-v`, and no `-v`'s. Got many debug logs with `-vv`.