### PR TITLE
Pass null stdin to discovery service

### DIFF
--- a/packages/service/ni_measurement_plugin_sdk_service/discovery/_support.py
+++ b/packages/service/ni_measurement_plugin_sdk_service/discovery/_support.py
@@ -84,6 +84,7 @@ def _start_service(
     discovery_service_subprocess = subprocess.Popen(  # nosec: B603
         [exe_file_path],
         cwd=exe_file_path.parent,
+        stdin=subprocess.DEVNULL,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
         **kwargs,

--- a/packages/service/tests/unit/test_discovery_client.py
+++ b/packages/service/tests/unit/test_discovery_client.py
@@ -258,6 +258,7 @@ def test___discovery_service_not_running___get_discovery_service_address___start
     mock_popen.assert_called_once_with(
         [exe_file_path],
         cwd=exe_file_path.parent,
+        stdin=subprocess.DEVNULL,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
         **subprocess_popen_kwargs,
@@ -326,6 +327,7 @@ def test___key_file_exist_after_poll___start_discovery_service___discovery_servi
     mock_popen.assert_called_once_with(
         [exe_file_path],
         cwd=exe_file_path.parent,
+        stdin=subprocess.DEVNULL,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
         **subprocess_popen_kwargs,


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Uses a null STDIN handle when starting the discovery service, so that the discovery service doesn't steal STDIN from the shell.

### Why should this Pull Request be merged?

Fixes #943 

### What testing has been done?

Reproduced the issue by killing the discovery service and running plugin-client-generator, and did the same to verify the fix.