### PR TITLE
Adding Output Support for Double2DArray for Client Generator and Service and updating Sample Measurement Example

### DIFF
--- a/examples/sample_measurement/measurement.py
+++ b/examples/sample_measurement/measurement.py
@@ -61,7 +61,7 @@ class Color(Enum):
     "Protobuf Enum out", nims.DataType.Enum, enum_type=color_pb2.ProtobufColor
 )
 @measurement_service.output("String Array out", nims.DataType.StringArray1D)
-@measurement_service.output("Double2DArray Out", nims.DataType.Double2DArray)
+@measurement_service.output("Double 2D Array Out", nims.DataType.Double2DArray)
 def measure(
     float_input: float,
     double_array_input: Iterable[float],
@@ -95,7 +95,7 @@ def measure(
     enum_output = enum_input
     protobuf_enum_output = protobuf_enum_input
     string_array_output = string_array_in
-    double2d_array_output = array_pb2.Double2DArray()
+    double_2d_array_output = array_pb2.Double2DArray()
     logging.info("Completed measurement")
 
     return (
@@ -106,7 +106,7 @@ def measure(
         enum_output,
         protobuf_enum_output,
         string_array_output,
-        double2d_array_output,
+        double_2d_array_output,
     )
 
 

--- a/examples/sample_measurement/measurement.py
+++ b/examples/sample_measurement/measurement.py
@@ -9,6 +9,7 @@ from typing import Iterable, Tuple
 import click
 import ni_measurement_plugin_sdk_service as nims
 from _helpers import configure_logging, verbosity_option
+from ni_measurement_plugin_sdk_service._internal.stubs.ni.protobuf.types import array_pb2
 
 try:
     from _stubs import color_pb2
@@ -60,6 +61,7 @@ class Color(Enum):
     "Protobuf Enum out", nims.DataType.Enum, enum_type=color_pb2.ProtobufColor
 )
 @measurement_service.output("String Array out", nims.DataType.StringArray1D)
+@measurement_service.output("Double2DArray Out", nims.DataType.Double2DArray)
 def measure(
     float_input: float,
     double_array_input: Iterable[float],
@@ -69,7 +71,14 @@ def measure(
     protobuf_enum_input: color_pb2.ProtobufColor.ValueType,
     string_array_in: Iterable[str],
 ) -> Tuple[
-    float, Iterable[float], bool, str, Color, color_pb2.ProtobufColor.ValueType, Iterable[str]
+    float,
+    Iterable[float],
+    bool,
+    str,
+    Color,
+    color_pb2.ProtobufColor.ValueType,
+    Iterable[str],
+    array_pb2.Double2DArray,
 ]:
     """Perform a loopback measurement with various data types."""
     logging.info("Executing measurement")
@@ -85,7 +94,8 @@ def measure(
     string_output = string_input
     enum_output = enum_input
     protobuf_enum_output = protobuf_enum_input
-    string_array_out = string_array_in
+    string_array_output = string_array_in
+    double2d_array_output = array_pb2.Double2DArray()
     logging.info("Completed measurement")
 
     return (
@@ -95,7 +105,8 @@ def measure(
         string_output,
         enum_output,
         protobuf_enum_output,
-        string_array_out,
+        string_array_output,
+        double2d_array_output,
     )
 
 

--- a/examples/sample_measurement/pyproject.toml
+++ b/examples/sample_measurement/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-ni-measurement-plugin-sdk-service = {version = "^2.1.0"}
+ni-measurement-plugin-sdk-service = {version = "^2.1.0", allow-prereleases = true}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 
 [tool.poetry.group.dev.dependencies]
@@ -18,7 +18,7 @@ grpcio-tools = "1.49.1"
 mypy-protobuf = "^3.6.0"
 types-protobuf = "^4.21"
 # Uncomment to use prerelease dependencies.
-# ni-measurement-plugin-sdk-service = {path = "../../packages/service", develop = true}
+ni-measurement-plugin-sdk-service = {path = "../../packages/service", develop = true}
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/packages/generator/ni_measurement_plugin_sdk_generator/client/__init__.py
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/client/__init__.py
@@ -86,6 +86,7 @@ def _create_client(
     output_parameters_with_type = get_output_parameters_with_type(
         output_metadata, built_in_import_modules, custom_import_modules, enum_values_by_type
     )
+    custom_import_modules.sort()
 
     _create_file(
         template_name="measurement_plugin_client.py.mako",

--- a/packages/generator/ni_measurement_plugin_sdk_generator/client/_support.py
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/client/_support.py
@@ -33,6 +33,7 @@ _V2_MEASUREMENT_SERVICE_INTERFACE = "ni.measurementlink.measurement.v2.Measureme
 _INVALID_CHARS = "`~!@#$%^&*()-+={}[]\\|:;',<>.?/ \n"
 
 _XY_DATA_IMPORT = "from ni_measurement_plugin_sdk_service._internal.stubs.ni.protobuf.types.xydata_pb2 import DoubleXYData"
+_2DARRAY_DATA_IMPORT = "from ni_measurement_plugin_sdk_service._internal.stubs.ni.protobuf.types.array_pb2 import Double2DArray"
 _PATH_IMPORT = "import pathlib"
 
 _PROTO_DATATYPE_TO_PYTYPE_LOOKUP = {
@@ -153,9 +154,13 @@ def get_configuration_and_output_metadata_by_index(
 
     output_parameter_list = []
     for output in metadata.measurement_signature.outputs:
-        if output.message_type and output.message_type != "ni.protobuf.types.DoubleXYData":
+        if (
+            output.message_type
+            and output.message_type != "ni.protobuf.types.DoubleXYData"
+            and output.message_type != "ni.protobuf.types.Double2DArray"
+        ):
             raise click.ClickException(
-                f"Measurement outputs do not support {output.message_type}. Only DoubleXYData is supported."
+                f"Measurement outputs do not support {output.message_type}. Only DoubleXYData and Double2DArray is supported."
             )
 
         annotations_dict = dict(output.annotations.items())
@@ -290,6 +295,13 @@ def get_output_parameters_with_type(
         if metadata.message_type and metadata.message_type == "ni.protobuf.types.DoubleXYData":
             parameter_type = "DoubleXYData"
             custom_import_modules.append(_XY_DATA_IMPORT)
+
+            if metadata.repeated:
+                parameter_type = f"typing.Sequence[{parameter_type}]"
+
+        if metadata.message_type and metadata.message_type == "ni.protobuf.types.Double2DArray":
+            parameter_type = "Double2DArray"
+            custom_import_modules.append(_2DARRAY_DATA_IMPORT)
 
             if metadata.repeated:
                 parameter_type = f"typing.Sequence[{parameter_type}]"

--- a/packages/generator/ni_measurement_plugin_sdk_generator/client/_support.py
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/client/_support.py
@@ -154,10 +154,10 @@ def get_configuration_and_output_metadata_by_index(
 
     output_parameter_list = []
     for output in metadata.measurement_signature.outputs:
-        if (
-            output.message_type
-            and output.message_type not in ["ni.protobuf.types.DoubleXYData", "ni.protobuf.types.Double2DArray"]
-        ):
+        if output.message_type and output.message_type not in [
+            "ni.protobuf.types.DoubleXYData",
+            "ni.protobuf.types.Double2DArray",
+        ]:
             raise click.ClickException(
                 f"Measurement outputs do not support {output.message_type}. Only DoubleXYData and Double2DArray are supported."
             )

--- a/packages/generator/ni_measurement_plugin_sdk_generator/client/_support.py
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/client/_support.py
@@ -156,11 +156,10 @@ def get_configuration_and_output_metadata_by_index(
     for output in metadata.measurement_signature.outputs:
         if (
             output.message_type
-            and output.message_type != "ni.protobuf.types.DoubleXYData"
-            and output.message_type != "ni.protobuf.types.Double2DArray"
+            and output.message_type not in ["ni.protobuf.types.DoubleXYData", "ni.protobuf.types.Double2DArray"]
         ):
             raise click.ClickException(
-                f"Measurement outputs do not support {output.message_type}. Only DoubleXYData and Double2DArray is supported."
+                f"Measurement outputs do not support {output.message_type}. Only DoubleXYData and Double2DArray are supported."
             )
 
         annotations_dict = dict(output.annotations.items())
@@ -304,7 +303,10 @@ def get_output_parameters_with_type(
             custom_import_modules.append(_2DARRAY_DATA_IMPORT)
 
             if metadata.repeated:
-                parameter_type = f"typing.Sequence[{parameter_type}]"
+                raise click.ClickException(
+                    f"Repeated Double 2D Array are not supported for output parameter "
+                    f"'{parameter_name}'. Please contact the measurement developer."
+                )
 
         if metadata.annotations and metadata.annotations.get("ni/type_specialization") == "enum":
             enum_type_name = _get_enum_type(

--- a/packages/generator/tests/acceptance/test_non_streaming_measurement_client.py
+++ b/packages/generator/tests/acceptance/test_non_streaming_measurement_client.py
@@ -65,7 +65,7 @@ def test___measurement_plugin_client___measure___returns_output(
         enum_out=EnumInEnum.BLUE,
         enum_array_out=[EnumInEnum.RED, EnumInEnum.GREEN],
         protobuf_enum_out=ProtobufEnumInEnum.BLACK,
-        double2darray_out=None,
+        double_2d_array_out=None,
     )
     measurement_plugin_client = test_measurement_client_type()
 
@@ -121,7 +121,7 @@ def test___measurement_plugin_client___stream_measure___returns_output(
         enum_out=EnumInEnum.BLUE,
         enum_array_out=[EnumInEnum.RED, EnumInEnum.GREEN],
         protobuf_enum_out=ProtobufEnumInEnum.BLACK,
-        double2darray_out=None,
+        double_2d_array_out=None,
     )
     measurement_plugin_client = test_measurement_client_type()
 
@@ -219,7 +219,7 @@ def _verify_output_types(outputs: Any, measurement_plugin_client_module: ModuleT
     _assert_type(outputs.enum_out, enum_type)
     _assert_collection_type(outputs.enum_array_out, Sequence, enum_type)
     _assert_type(outputs.protobuf_enum_out, protobuf_enum_type)
-    _assert_type(outputs.double2darray_out, type(None))
+    _assert_type(outputs.double_2d_array_out, type(None))
 
 
 def _assert_type(value: Any, expected_type: Union[Type[Any], Tuple[Type[Any], ...]]) -> None:

--- a/packages/generator/tests/acceptance/test_non_streaming_measurement_client.py
+++ b/packages/generator/tests/acceptance/test_non_streaming_measurement_client.py
@@ -65,6 +65,7 @@ def test___measurement_plugin_client___measure___returns_output(
         enum_out=EnumInEnum.BLUE,
         enum_array_out=[EnumInEnum.RED, EnumInEnum.GREEN],
         protobuf_enum_out=ProtobufEnumInEnum.BLACK,
+        double2darray_out=None,
     )
     measurement_plugin_client = test_measurement_client_type()
 
@@ -120,6 +121,7 @@ def test___measurement_plugin_client___stream_measure___returns_output(
         enum_out=EnumInEnum.BLUE,
         enum_array_out=[EnumInEnum.RED, EnumInEnum.GREEN],
         protobuf_enum_out=ProtobufEnumInEnum.BLACK,
+        double2darray_out=None,
     )
     measurement_plugin_client = test_measurement_client_type()
 
@@ -217,6 +219,7 @@ def _verify_output_types(outputs: Any, measurement_plugin_client_module: ModuleT
     _assert_type(outputs.enum_out, enum_type)
     _assert_collection_type(outputs.enum_array_out, Sequence, enum_type)
     _assert_type(outputs.protobuf_enum_out, protobuf_enum_type)
+    _assert_type(outputs.double2darray_out, type(None))
 
 
 def _assert_type(value: Any, expected_type: Union[Type[Any], Tuple[Type[Any], ...]]) -> None:

--- a/packages/generator/tests/test_assets/example_renders/measurement_plugin_client/non_streaming_data_measurement_client.py
+++ b/packages/generator/tests/test_assets/example_renders/measurement_plugin_client/non_streaming_data_measurement_client.py
@@ -74,7 +74,7 @@ class Outputs(typing.NamedTuple):
     enum_out: EnumInEnum
     enum_array_out: typing.Sequence[EnumInEnum]
     protobuf_enum_out: ProtobufEnumInEnum
-    double2darray_out: Double2DArray
+    double_2d_array_out: Double2DArray
 
 
 class NonStreamingDataMeasurementClient:
@@ -427,13 +427,13 @@ class NonStreamingDataMeasurementClient:
                 enum_type=ProtobufEnumInEnum,
             ),
             15: ParameterMetadata(
-                display_name="Double2DArray out",
+                display_name="Double 2D Array out",
                 type=Field.Kind.ValueType(11),
                 repeated=False,
                 default_value=None,
                 annotations={},
                 message_type="ni.protobuf.types.Double2DArray",
-                field_name="Double2DArray_out",
+                field_name="Double_2D_Array_out",
                 enum_type=None,
             ),
         }

--- a/packages/generator/tests/test_assets/example_renders/measurement_plugin_client/non_streaming_data_measurement_client.py
+++ b/packages/generator/tests/test_assets/example_renders/measurement_plugin_client/non_streaming_data_measurement_client.py
@@ -16,6 +16,9 @@ from ni_measurement_plugin_sdk_service._internal.stubs.ni.measurementlink.measur
     measurement_service_pb2 as v2_measurement_service_pb2,
     measurement_service_pb2_grpc as v2_measurement_service_pb2_grpc,
 )
+from ni_measurement_plugin_sdk_service._internal.stubs.ni.protobuf.types.array_pb2 import (
+    Double2DArray,
+)
 from ni_measurement_plugin_sdk_service._internal.stubs.ni.protobuf.types.xydata_pb2 import (
     DoubleXYData,
 )
@@ -71,6 +74,7 @@ class Outputs(typing.NamedTuple):
     enum_out: EnumInEnum
     enum_array_out: typing.Sequence[EnumInEnum]
     protobuf_enum_out: ProtobufEnumInEnum
+    double2darray_out: Double2DArray
 
 
 class NonStreamingDataMeasurementClient:
@@ -421,6 +425,16 @@ class NonStreamingDataMeasurementClient:
                 message_type="",
                 field_name="Protobuf_Enum_out",
                 enum_type=ProtobufEnumInEnum,
+            ),
+            15: ParameterMetadata(
+                display_name="Double2DArray out",
+                type=Field.Kind.ValueType(11),
+                repeated=False,
+                default_value=None,
+                annotations={},
+                message_type="ni.protobuf.types.Double2DArray",
+                field_name="Double2DArray_out",
+                enum_type=None,
             ),
         }
         if grpc_channel is not None:

--- a/packages/generator/tests/utilities/measurements/non_streaming_data_measurement/__init__.py
+++ b/packages/generator/tests/utilities/measurements/non_streaming_data_measurement/__init__.py
@@ -5,10 +5,12 @@ from pathlib import Path
 from typing import Iterable, Tuple
 
 import ni_measurement_plugin_sdk_service as nims
-from ni_measurement_plugin_sdk_service._internal.stubs.ni.protobuf.types import xydata_pb2
+from ni_measurement_plugin_sdk_service._internal.stubs.ni.protobuf.types import (
+    array_pb2,
+    xydata_pb2,
+)
 
 from tests.utilities.measurements.non_streaming_data_measurement._stubs import color_pb2
-
 
 service_directory = Path(__file__).resolve().parent
 measurement_service = nims.MeasurementService(
@@ -89,6 +91,7 @@ class Color(Enum):
 @measurement_service.output(
     "Protobuf Enum out", nims.DataType.Enum, enum_type=color_pb2.ProtobufColor
 )
+@measurement_service.output("Double2DArray out", nims.DataType.Double2DArray)
 def measure(
     float_input: float,
     double_array_input: Iterable[float],
@@ -118,6 +121,7 @@ def measure(
     Color,
     Iterable[Color],
     color_pb2.ProtobufColor.ValueType,
+    array_pb2.Double2DArray,
 ]:
     """Perform a loopback measurement with various data types."""
     float_output = float_input
@@ -134,6 +138,7 @@ def measure(
     enum_output = enum_input
     enum_array_output = enum_array_input
     protobuf_enum_output = protobuf_enum_input
+    double2d_array_output = array_pb2.Double2DArray()
 
     return (
         float_output,
@@ -150,4 +155,5 @@ def measure(
         enum_output,
         enum_array_output,
         protobuf_enum_output,
+        double2d_array_output,
     )

--- a/packages/generator/tests/utilities/measurements/non_streaming_data_measurement/__init__.py
+++ b/packages/generator/tests/utilities/measurements/non_streaming_data_measurement/__init__.py
@@ -91,7 +91,7 @@ class Color(Enum):
 @measurement_service.output(
     "Protobuf Enum out", nims.DataType.Enum, enum_type=color_pb2.ProtobufColor
 )
-@measurement_service.output("Double2DArray out", nims.DataType.Double2DArray)
+@measurement_service.output("Double 2D Array out", nims.DataType.Double2DArray)
 def measure(
     float_input: float,
     double_array_input: Iterable[float],
@@ -138,7 +138,7 @@ def measure(
     enum_output = enum_input
     enum_array_output = enum_array_input
     protobuf_enum_output = protobuf_enum_input
-    double2d_array_output = array_pb2.Double2DArray()
+    double_2d_array_output = array_pb2.Double2DArray()
 
     return (
         float_output,
@@ -155,5 +155,5 @@ def measure(
         enum_output,
         enum_array_output,
         protobuf_enum_output,
-        double2d_array_output,
+        double_2d_array_output,
     )

--- a/packages/service/ni_measurement_plugin_sdk_service/_datatypeinfo.py
+++ b/packages/service/ni_measurement_plugin_sdk_service/_datatypeinfo.py
@@ -2,6 +2,7 @@ from typing import NamedTuple
 
 from google.protobuf import type_pb2
 
+from ni_measurement_plugin_sdk_service._internal.stubs.ni.protobuf.types import array_pb2
 from ni_measurement_plugin_sdk_service._internal.stubs.ni.protobuf.types import xydata_pb2
 from ni_measurement_plugin_sdk_service.measurement.info import DataType, TypeSpecialization
 
@@ -50,6 +51,11 @@ _DATATYPE_TO_DATATYPEINFO_LOOKUP = {
         type_pb2.Field.TYPE_MESSAGE,
         False,
         message_type=xydata_pb2.DoubleXYData.DESCRIPTOR.full_name,
+    ),
+    DataType.Double2DArray: DataTypeInfo(
+        type_pb2.Field.TYPE_MESSAGE,
+        False,
+        message_type=array_pb2.Double2DArray.DESCRIPTOR.full_name,
     ),
     DataType.IOResource: DataTypeInfo(
         type_pb2.Field.TYPE_STRING, False, TypeSpecialization.IOResource

--- a/packages/service/ni_measurement_plugin_sdk_service/measurement/info.py
+++ b/packages/service/ni_measurement_plugin_sdk_service/measurement/info.py
@@ -107,6 +107,7 @@ class DataType(enum.Enum):
     Enum = 10
     DoubleXYData = 11
     IOResource = 12
+    Double2DArray = 13
 
     Int32Array1D = 100
     Int64Array1D = 101

--- a/packages/service/tests/unit/test_service.py
+++ b/packages/service/tests/unit/test_service.py
@@ -67,6 +67,7 @@ def test___measurement_service___register_measurement_method___method_registered
         ("UInt64", DataType.UInt64, False),
         ("DoubleXYData", DataType.DoubleXYData, None),
         ("DoubleXYDataArray", DataType.DoubleXYDataArray1D, None),
+        ("Double2DArray", DataType.Double2DArray, None),
     ],
 )
 def test___measurement_service___add_configuration__configuration_added(
@@ -294,6 +295,7 @@ def test___measurement_service___add_non_path_configuration__path_type_annotatio
         ("Path", DataType.Path, 1.0),
         ("Path1DArray", DataType.PathArray1D, [1.009, -1.0009]),
         ("DoubleXYDataArray", DataType.DoubleXYDataArray1D, [1.009, -1.0009]),
+        ("Double2DArray", DataType.Double2DArray, 12),
     ],
 )
 @pytest.mark.filterwarnings("ignore:.*Pin.*:DeprecationWarning")
@@ -323,6 +325,7 @@ def test___measurement_service___add_configuration_with_mismatch_default_value__
         ("UInt64", DataType.UInt64),
         ("DoubleXYData", DataType.DoubleXYData),
         ("DoubleXYDataArray", DataType.DoubleXYDataArray1D),
+        ("Double2DArray", DataType.Double2DArray),
     ],
 )
 def test___measurement_service___add_output__output_added(


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Adding Support for Double2DArray Output for Client Generator and Service and updating Sample Measurement Example.

### Why should this Pull Request be merged?

Add Double2DArray Output support for measurements.

### What testing has been done?

- All automated tests for Client Generator and Service are running fine after adding Double2DArray output parameter.
- Measurement is running fine through command-line.
- Additional testing on MeasurementUI Editor by dropping Control and Indicator and connecting to measurement produce desired behavior.