### PR TITLE
Input Support for Double2dArray for Client Generator and Service and updating Sample Measurement

### DIFF
--- a/examples/sample_measurement/measurement.py
+++ b/examples/sample_measurement/measurement.py
@@ -52,6 +52,11 @@ class Color(Enum):
 @measurement_service.configuration(
     "String Array In", nims.DataType.StringArray1D, ["String1", "String2"]
 )
+@measurement_service.configuration(
+    "Double 2D Array In",
+    nims.DataType.Double2DArray,
+    array_pb2.Double2DArray(rows=2, columns=3, data=[1, 2, 3, 4, 5, 6]),
+)
 @measurement_service.output("Float out", nims.DataType.Float)
 @measurement_service.output("Double Array out", nims.DataType.DoubleArray1D)
 @measurement_service.output("Bool out", nims.DataType.Boolean)
@@ -70,6 +75,7 @@ def measure(
     enum_input: Color,
     protobuf_enum_input: color_pb2.ProtobufColor.ValueType,
     string_array_in: Iterable[str],
+    double_2d_array_input: array_pb2.Double2DArray,
 ) -> Tuple[
     float,
     Iterable[float],
@@ -95,7 +101,7 @@ def measure(
     enum_output = enum_input
     protobuf_enum_output = protobuf_enum_input
     string_array_output = string_array_in
-    double_2d_array_output = array_pb2.Double2DArray()
+    double_2d_array_output = double_2d_array_input
     logging.info("Completed measurement")
 
     return (

--- a/packages/generator/ni_measurement_plugin_sdk_generator/client/__init__.py
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/client/__init__.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional, Type
 
 import black
 import click
-from click_option_group import optgroup, RequiredMutuallyExclusiveOptionGroup
+from click_option_group import RequiredMutuallyExclusiveOptionGroup, optgroup
 from mako.template import Template
 from ni_measurement_plugin_sdk_service._internal.stubs.ni.measurementlink.measurement.v2 import (
     measurement_service_pb2 as v2_measurement_service_pb2,
@@ -19,18 +19,17 @@ from ni_measurement_plugin_sdk_generator.client._support import (
     create_class_name,
     create_module_name,
     extract_base_service_class,
+    get_all_registered_measurement_info,
     get_configuration_and_output_metadata_by_index,
     get_configuration_parameters_with_type_and_default_values,
     get_measurement_service_stub_and_version,
     get_output_parameters_with_type,
-    get_all_registered_measurement_info,
     get_selected_measurement_service_class,
-    to_ordered_set,
     resolve_output_directory,
+    to_ordered_set,
     validate_identifier,
     validate_measurement_service_classes,
 )
-
 
 _CLIENT_CREATION_ERROR_MESSAGE = "Client creation failed for '{}'. Possible reason(s): {}"
 

--- a/packages/generator/ni_measurement_plugin_sdk_generator/client/_support.py
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/client/_support.py
@@ -80,7 +80,8 @@ _CAMEL_TO_SNAKE_CASE_REGEXES = [
 
 
 def _format_default_value(value: Any) -> Any:
-    """Formats the default value for the given value. Used for generating the service's metadata structs."""
+    """Formats the default value for the given value.
+    Used for generating the service's metadata structs."""
     if isinstance(value, str):
         return repr(value)
     elif isinstance(value, Double2DArray):
@@ -255,7 +256,8 @@ def get_configuration_parameters_with_type_and_default_values(
     built_in_import_modules: List[str],
     enum_values_by_type: Dict[Type[Enum], Dict[str, int]] = {},
 ) -> Tuple[str, str]:
-    """Returns configuration parameters of the measurement with type and default values. Used to generate Client API class's measure() parameter list."""
+    """Returns configuration parameters of the measurement with type and default values.
+    Used to generate Client API class's measure() parameter list."""
     configuration_parameters = []
     parameter_names = []
 

--- a/packages/generator/ni_measurement_plugin_sdk_generator/client/_support.py
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/client/_support.py
@@ -124,7 +124,10 @@ def get_configuration_and_output_metadata_by_index(
     """Returns the configuration and output metadata of the measurement."""
     configuration_parameter_list = []
     for configuration in metadata.measurement_signature.configuration_parameters:
-        if configuration.message_type and configuration.message_type != "ni.protobuf.types.Double2DArray":
+        if (
+            configuration.message_type
+            and configuration.message_type != "ni.protobuf.types.Double2DArray"
+        ):
             raise click.ClickException(
                 f"Measurement configurations do not support message data types ({configuration.message_type} is unsupported)."
             )
@@ -273,7 +276,7 @@ def get_configuration_parameters_with_type_and_default_values(
             else:
                 enum_value = next((e.name for e in enum_type if e.value == default_value), None)
                 default_value = f"{parameter_type}.{enum_value}"
-        
+
         if metadata.message_type and metadata.message_type == "ni.protobuf.types.Double2DArray":
             parameter_type = "Double2DArray"
 

--- a/packages/generator/ni_measurement_plugin_sdk_generator/client/_support.py
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/client/_support.py
@@ -80,8 +80,10 @@ _CAMEL_TO_SNAKE_CASE_REGEXES = [
 
 
 def _format_default_value(value: Any) -> Any:
-    """Formats the default value for the given value.
-    Used for generating the service's metadata structs."""
+    """Format the default value for the given value.
+
+    Used for generating the service's metadata structs.
+    """
     if isinstance(value, str):
         return repr(value)
     elif isinstance(value, Double2DArray):
@@ -256,8 +258,10 @@ def get_configuration_parameters_with_type_and_default_values(
     built_in_import_modules: List[str],
     enum_values_by_type: Dict[Type[Enum], Dict[str, int]] = {},
 ) -> Tuple[str, str]:
-    """Returns configuration parameters of the measurement with type and default values.
-    Used to generate Client API class's measure() parameter list."""
+    """Return configuration parameters of the measurement with type and default values.
+
+    Used to generate Client API class's measure() parameter list.
+    """
     configuration_parameters = []
     parameter_names = []
 

--- a/packages/generator/ni_measurement_plugin_sdk_generator/client/templates/measurement_plugin_client.py.mako
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/client/templates/measurement_plugin_client.py.mako
@@ -1,17 +1,11 @@
 <%!
 import re
 from typing import Any
+from ni_measurement_plugin_sdk_generator.client._support import _format_default_value
 %>\
 \
 <%page args="class_name, display_name, version, configuration_metadata, output_metadata, service_class, configuration_parameters_with_type_and_default_values, measure_api_parameters, output_parameters_with_type, built_in_import_modules, custom_import_modules, enum_by_class_name, configuration_parameters_type_url, outputs_message_type"/>\
 \
-<%
-    def _format_default_value(value: Any) -> Any:
-        if isinstance(value, str):
-            return repr(value)
-        else:
-            return value
-%>\
 \
 
 """Generated client API for the ${display_name | repr} measurement plug-in."""
@@ -120,7 +114,7 @@ class ${class_name}:
                 display_name=${value.display_name | repr},
                 type=Field.Kind.ValueType(${value.type}),
                 repeated=${value.repeated},
-                default_value=${value.default_value},
+                default_value=${_format_default_value(value.default_value)},
                 annotations=${value.annotations | n, repr},
                 message_type=${value.message_type | repr},
                 field_name=${value.field_name | repr},
@@ -138,7 +132,7 @@ class ${class_name}:
                 display_name=${value.display_name | repr},
                 type=Field.Kind.ValueType(${value.type}),
                 repeated=${value.repeated},
-                default_value=${value.default_value},
+                default_value=${_format_default_value(value.default_value)},
                 annotations=${value.annotations | n, repr},
                 message_type=${value.message_type | repr},
                 field_name=${value.field_name | repr},

--- a/packages/generator/ni_measurement_plugin_sdk_generator/client/templates/measurement_plugin_client.py.mako
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/client/templates/measurement_plugin_client.py.mako
@@ -120,7 +120,7 @@ class ${class_name}:
                 display_name=${value.display_name | repr},
                 type=Field.Kind.ValueType(${value.type}),
                 repeated=${value.repeated},
-                default_value=${_format_default_value(value.default_value)},
+                default_value=${value.default_value},
                 annotations=${value.annotations | n, repr},
                 message_type=${value.message_type | repr},
                 field_name=${value.field_name | repr},

--- a/packages/generator/tests/acceptance/test_non_streaming_measurement_client.py
+++ b/packages/generator/tests/acceptance/test_non_streaming_measurement_client.py
@@ -11,7 +11,9 @@ from ni_measurement_plugin_sdk_service.measurement.service import MeasurementSer
 from tests.conftest import CliRunnerFunction
 from tests.utilities.discovery_service_process import DiscoveryServiceProcess
 from tests.utilities.measurements import non_streaming_data_measurement
-
+from ni_measurement_plugin_sdk_service._internal.stubs.ni.protobuf.types import (
+    array_pb2,
+)
 
 class EnumInEnum(Enum):
     """EnumInEnum used for enum-typed measurement configs and outputs."""
@@ -65,7 +67,7 @@ def test___measurement_plugin_client___measure___returns_output(
         enum_out=EnumInEnum.BLUE,
         enum_array_out=[EnumInEnum.RED, EnumInEnum.GREEN],
         protobuf_enum_out=ProtobufEnumInEnum.BLACK,
-        double_2d_array_out=None,
+        double_2d_array_out=array_pb2.Double2DArray(rows=2, columns=3, data=[1, 2, 3, 4, 5, 6]),
     )
     measurement_plugin_client = test_measurement_client_type()
 
@@ -121,7 +123,7 @@ def test___measurement_plugin_client___stream_measure___returns_output(
         enum_out=EnumInEnum.BLUE,
         enum_array_out=[EnumInEnum.RED, EnumInEnum.GREEN],
         protobuf_enum_out=ProtobufEnumInEnum.BLACK,
-        double_2d_array_out=None,
+        double_2d_array_out=array_pb2.Double2DArray(rows=2, columns=3, data=[1, 2, 3, 4, 5, 6]),
     )
     measurement_plugin_client = test_measurement_client_type()
 
@@ -219,7 +221,7 @@ def _verify_output_types(outputs: Any, measurement_plugin_client_module: ModuleT
     _assert_type(outputs.enum_out, enum_type)
     _assert_collection_type(outputs.enum_array_out, Sequence, enum_type)
     _assert_type(outputs.protobuf_enum_out, protobuf_enum_type)
-    _assert_type(outputs.double_2d_array_out, type(None))
+    _assert_type(outputs.double_2d_array_out, array_pb2.Double2DArray)
 
 
 def _assert_type(value: Any, expected_type: Union[Type[Any], Tuple[Type[Any], ...]]) -> None:

--- a/packages/generator/tests/acceptance/test_non_streaming_measurement_client.py
+++ b/packages/generator/tests/acceptance/test_non_streaming_measurement_client.py
@@ -6,14 +6,15 @@ from types import ModuleType
 from typing import Any, Generator, Tuple, Type, Union
 
 import pytest
+from ni_measurement_plugin_sdk_service._internal.stubs.ni.protobuf.types import (
+    array_pb2,
+)
 from ni_measurement_plugin_sdk_service.measurement.service import MeasurementService
 
 from tests.conftest import CliRunnerFunction
 from tests.utilities.discovery_service_process import DiscoveryServiceProcess
 from tests.utilities.measurements import non_streaming_data_measurement
-from ni_measurement_plugin_sdk_service._internal.stubs.ni.protobuf.types import (
-    array_pb2,
-)
+
 
 class EnumInEnum(Enum):
     """EnumInEnum used for enum-typed measurement configs and outputs."""

--- a/packages/generator/tests/test_assets/example_renders/measurement_plugin_client/non_streaming_data_measurement_client.py
+++ b/packages/generator/tests/test_assets/example_renders/measurement_plugin_client/non_streaming_data_measurement_client.py
@@ -595,7 +595,9 @@ class NonStreamingDataMeasurementClient:
         enum_in: EnumInEnum = EnumInEnum.BLUE,
         enum_array_in: typing.Iterable[EnumInEnum] = [EnumInEnum.RED, EnumInEnum.GREEN],
         protobuf_enum_in: ProtobufEnumInEnum = ProtobufEnumInEnum.BLACK,
-        double_2d_array_in: Double2DArray = Double2DArray(rows=2, columns=3, data=[1, 2, 3, 4, 5, 6]),
+        double_2d_array_in: Double2DArray = Double2DArray(
+            rows=2, columns=3, data=[1, 2, 3, 4, 5, 6]
+        ),
     ) -> Outputs:
         """Perform a single measurement.
 
@@ -651,7 +653,9 @@ class NonStreamingDataMeasurementClient:
         enum_in: EnumInEnum = EnumInEnum.BLUE,
         enum_array_in: typing.Iterable[EnumInEnum] = [EnumInEnum.RED, EnumInEnum.GREEN],
         protobuf_enum_in: ProtobufEnumInEnum = ProtobufEnumInEnum.BLACK,
-        double_2d_array_in: Double2DArray = Double2DArray(rows=2, columns=3, data=[1, 2, 3, 4, 5, 6]),
+        double_2d_array_in: Double2DArray = Double2DArray(
+            rows=2, columns=3, data=[1, 2, 3, 4, 5, 6]
+        ),
     ) -> typing.Generator[Outputs, None, None]:
         """Perform a streaming measurement.
 

--- a/packages/generator/tests/test_assets/example_renders/measurement_plugin_client/non_streaming_data_measurement_client.py
+++ b/packages/generator/tests/test_assets/example_renders/measurement_plugin_client/non_streaming_data_measurement_client.py
@@ -269,6 +269,16 @@ class NonStreamingDataMeasurementClient:
                 field_name="Protobuf_Enum_In",
                 enum_type=ProtobufEnumInEnum,
             ),
+            14: ParameterMetadata(
+                display_name="Double 2D Array In",
+                type=Field.Kind.ValueType(11),
+                repeated=False,
+                default_value=Double2DArray(rows=2, columns=3, data=[1, 2, 3, 4, 5, 6]),
+                annotations={},
+                message_type="ni.protobuf.types.Double2DArray",
+                field_name="Double_2D_Array_In",
+                enum_type=None,
+            ),
         }
         self._output_metadata = {
             1: ParameterMetadata(
@@ -585,6 +595,7 @@ class NonStreamingDataMeasurementClient:
         enum_in: EnumInEnum = EnumInEnum.BLUE,
         enum_array_in: typing.Iterable[EnumInEnum] = [EnumInEnum.RED, EnumInEnum.GREEN],
         protobuf_enum_in: ProtobufEnumInEnum = ProtobufEnumInEnum.BLACK,
+        double_2d_array_in: Double2DArray = Double2DArray(rows=2, columns=3, data=[1, 2, 3, 4, 5, 6]),
     ) -> Outputs:
         """Perform a single measurement.
 
@@ -605,6 +616,7 @@ class NonStreamingDataMeasurementClient:
             enum_in,
             enum_array_in,
             protobuf_enum_in,
+            double_2d_array_in,
         )
         for response in stream_measure_response:
             result = response
@@ -639,6 +651,7 @@ class NonStreamingDataMeasurementClient:
         enum_in: EnumInEnum = EnumInEnum.BLUE,
         enum_array_in: typing.Iterable[EnumInEnum] = [EnumInEnum.RED, EnumInEnum.GREEN],
         protobuf_enum_in: ProtobufEnumInEnum = ProtobufEnumInEnum.BLACK,
+        double_2d_array_in: Double2DArray = Double2DArray(rows=2, columns=3, data=[1, 2, 3, 4, 5, 6]),
     ) -> typing.Generator[Outputs, None, None]:
         """Perform a streaming measurement.
 
@@ -659,6 +672,7 @@ class NonStreamingDataMeasurementClient:
             enum_in,
             enum_array_in,
             protobuf_enum_in,
+            double_2d_array_in,
         ]
         with self._initialization_lock:
             if self._measure_response is not None:

--- a/packages/generator/tests/utilities/measurements/non_streaming_data_measurement/__init__.py
+++ b/packages/generator/tests/utilities/measurements/non_streaming_data_measurement/__init__.py
@@ -75,6 +75,11 @@ class Color(Enum):
     color_pb2.ProtobufColor.BLACK,
     enum_type=color_pb2.ProtobufColor,
 )
+@measurement_service.configuration(
+    "Double 2D Array In",
+    nims.DataType.Double2DArray,
+    array_pb2.Double2DArray(rows=2, columns=3, data=[1, 2, 3, 4, 5, 6]),
+)
 @measurement_service.output("Float out", nims.DataType.Float)
 @measurement_service.output("Double Array out", nims.DataType.DoubleArray1D)
 @measurement_service.output("Bool out", nims.DataType.Boolean)
@@ -106,6 +111,7 @@ def measure(
     enum_input: Color,
     enum_array_input: Iterable[Color],
     protobuf_enum_input: color_pb2.ProtobufColor.ValueType,
+    double_2d_array_input: array_pb2.Double2DArray,
 ) -> Tuple[
     float,
     Iterable[float],
@@ -138,7 +144,7 @@ def measure(
     enum_output = enum_input
     enum_array_output = enum_array_input
     protobuf_enum_output = protobuf_enum_input
-    double_2d_array_output = array_pb2.Double2DArray()
+    double_2d_array_output = double_2d_array_input
 
     return (
         float_output,

--- a/packages/service/tests/unit/test_decoder.py
+++ b/packages/service/tests/unit/test_decoder.py
@@ -19,6 +19,7 @@ from ni_measurement_plugin_sdk_service._internal.parameter.metadata import (
     TypeSpecialization,
 )
 from ni_measurement_plugin_sdk_service._internal.stubs.ni.protobuf.types import (
+    array_pb2,
     xydata_pb2,
 )
 from tests.utilities.stubs.serialization import test_pb2
@@ -53,6 +54,8 @@ double_xy_data2.y_data.append(10)
 
 double_xy_data_array = [double_xy_data, double_xy_data2]
 
+double_2d_array = array_pb2.Double2DArray(rows=2, columns=3, data=[1, 2, 3, 4, 5, 6])
+
 # This should match the number of fields in bigmessage.proto.
 BIG_MESSAGE_SIZE = 100
 
@@ -83,6 +86,7 @@ BIG_MESSAGE_SIZE = 100
             [Countries.AUSTRALIA, Countries.CANADA],
             double_xy_data,
             double_xy_data_array,
+            double_2d_array,
         ]
     ],
 )
@@ -125,6 +129,7 @@ def test___empty_buffer___deserialize_parameters___returns_zero_or_empty():
         [Countries.AUSTRALIA, Countries.CANADA],
         double_xy_data,
         double_xy_data_array,
+        double_2d_array,
     ]
     parameter = _get_test_parameter_by_id(nonzero_defaults)
     service_name = _test_create_file_descriptor(list(parameter.values()), "empty_buffer")
@@ -347,6 +352,14 @@ def _get_test_parameter_by_id(default_values):
             annotations={},
             message_type=xydata_pb2.DoubleXYData.DESCRIPTOR.full_name,
         ),
+        23: ParameterMetadata.initialize(
+            display_name="double_2d_array",
+            type=type_pb2.Field.TYPE_MESSAGE,
+            repeated=False,
+            default_value=default_values[22],
+            annotations={},
+            message_type=array_pb2.Double2DArray.DESCRIPTOR.full_name,
+        ),
     }
     return parameter_by_id
 
@@ -376,6 +389,9 @@ def _get_test_grpc_message(test_values):
     parameter.xy_data.x_data.append(test_values[20].x_data[0])
     parameter.xy_data.y_data.append(test_values[20].y_data[0])
     parameter.xy_data_array.extend(test_values[21])
+    parameter.double_2d_array.rows = test_values[22].rows
+    parameter.double_2d_array.columns = test_values[22].columns
+    parameter.double_2d_array.data.extend(test_values[22].data)
     return parameter
 
 

--- a/packages/service/tests/unit/test_encoder.py
+++ b/packages/service/tests/unit/test_encoder.py
@@ -12,6 +12,7 @@ from ni_measurement_plugin_sdk_service._internal.parameter import (
     serialization_descriptors,
 )
 from ni_measurement_plugin_sdk_service._internal.stubs.ni.protobuf.types import (
+    array_pb2,
     xydata_pb2,
 )
 from tests.unit.test_decoder import (
@@ -51,6 +52,8 @@ double_xy_data2.y_data.append(10)
 
 double_xy_data_array = [double_xy_data, double_xy_data2]
 
+double_2d_array = array_pb2.Double2DArray(rows=2, columns=3, data=[1, 2, 3, 4, 5, 6])
+
 # This should match the number of fields in bigmessage.proto.
 BIG_MESSAGE_SIZE = 100
 
@@ -81,6 +84,7 @@ BIG_MESSAGE_SIZE = 100
             [Countries.AUSTRALIA, Countries.CANADA],
             double_xy_data,
             double_xy_data_array,
+            double_2d_array,
         ],
         [
             -0.9999,
@@ -105,6 +109,7 @@ BIG_MESSAGE_SIZE = 100
             [Countries.AUSTRALIA, Countries.CANADA],
             double_xy_data,
             double_xy_data_array,
+            double_2d_array,
         ],
     ],
 )
@@ -149,6 +154,7 @@ def test___serializer___serialize_parameter___successful_serialization(test_valu
             [Countries.AUSTRALIA, Countries.CANADA],
             double_xy_data,
             double_xy_data_array,
+            double_2d_array,
         ],
         [
             -0.9999,
@@ -173,6 +179,7 @@ def test___serializer___serialize_parameter___successful_serialization(test_valu
             [Countries.AUSTRALIA, Countries.CANADA],
             double_xy_data,
             double_xy_data_array,
+            double_2d_array,
         ],
     ],
 )
@@ -230,6 +237,7 @@ def test___big_message___serialize_parameters___returns_serialized_data() -> Non
             [Countries.AUSTRALIA, Countries.CANADA],
             double_xy_data,
             double_xy_data_array,
+            double_2d_array,
         ],
     ],
 )

--- a/packages/service/tests/utilities/stubs/serialization/test.proto
+++ b/packages/service/tests/utilities/stubs/serialization/test.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 package ni.measurementlink.measurement.tests.serialization;
 
+import "ni/protobuf/types/array.proto";
 import "ni/protobuf/types/xydata.proto";
 
 enum DifferentColor
@@ -42,4 +43,5 @@ message MeasurementParameter {
     repeated Countries int_enum_array_data = 20;
     ni.protobuf.types.DoubleXYData xy_data = 21;
     repeated ni.protobuf.types.DoubleXYData xy_data_array = 22;
+    ni.protobuf.types.Double2DArray double_2d_array = 23;
 }

--- a/packages/service/tests/utilities/stubs/serialization/test_pb2.py
+++ b/packages/service/tests/utilities/stubs/serialization/test_pb2.py
@@ -11,20 +11,21 @@ from google.protobuf import symbol_database as _symbol_database
 _sym_db = _symbol_database.Default()
 
 
+from ni_measurement_plugin_sdk_service._internal.stubs.ni.protobuf.types import array_pb2 as ni_dot_protobuf_dot_types_dot_array__pb2
 from ni_measurement_plugin_sdk_service._internal.stubs.ni.protobuf.types import xydata_pb2 as ni_dot_protobuf_dot_types_dot_xydata__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x18serialization/test.proto\x12\x32ni.measurementlink.measurement.tests.serialization\x1a\x1eni/protobuf/types/xydata.proto\"\xdc\x06\n\x14MeasurementParameter\x12\x12\n\nfloat_data\x18\x01 \x01(\x02\x12\x13\n\x0b\x64ouble_data\x18\x02 \x01(\x01\x12\x12\n\nint32_data\x18\x03 \x01(\x05\x12\x13\n\x0buint32_data\x18\x04 \x01(\r\x12\x12\n\nint64_data\x18\x05 \x01(\x03\x12\x13\n\x0buint64_data\x18\x06 \x01(\x04\x12\x11\n\tbool_data\x18\x07 \x01(\x08\x12\x13\n\x0bstring_data\x18\x08 \x01(\t\x12\x19\n\x11\x64ouble_array_data\x18\t \x03(\x01\x12\x18\n\x10\x66loat_array_data\x18\n \x03(\x02\x12\x18\n\x10int32_array_data\x18\x0b \x03(\x05\x12\x19\n\x11uint32_array_data\x18\x0c \x03(\r\x12\x18\n\x10int64_array_data\x18\r \x03(\x03\x12\x19\n\x11uint64_array_data\x18\x0e \x03(\x04\x12\x17\n\x0f\x62ool_array_data\x18\x0f \x03(\x08\x12\x19\n\x11string_array_data\x18\x10 \x03(\t\x12U\n\tenum_data\x18\x11 \x01(\x0e\x32\x42.ni.measurementlink.measurement.tests.serialization.DifferentColor\x12[\n\x0f\x65num_array_data\x18\x12 \x03(\x0e\x32\x42.ni.measurementlink.measurement.tests.serialization.DifferentColor\x12T\n\rint_enum_data\x18\x13 \x01(\x0e\x32=.ni.measurementlink.measurement.tests.serialization.Countries\x12Z\n\x13int_enum_array_data\x18\x14 \x03(\x0e\x32=.ni.measurementlink.measurement.tests.serialization.Countries\x12\x30\n\x07xy_data\x18\x15 \x01(\x0b\x32\x1f.ni.protobuf.types.DoubleXYData\x12\x36\n\rxy_data_array\x18\x16 \x03(\x0b\x32\x1f.ni.protobuf.types.DoubleXYData*=\n\x0e\x44ifferentColor\x12\n\n\x06PURPLE\x10\x00\x12\n\n\x06ORANGE\x10\x01\x12\x08\n\x04TEAL\x10\x02\x12\t\n\x05\x42ROWN\x10\x03*?\n\tCountries\x12\x0b\n\x07\x41MERICA\x10\x00\x12\n\n\x06TAIWAN\x10\x01\x12\r\n\tAUSTRALIA\x10\x02\x12\n\n\x06\x43\x41NADA\x10\x03\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x18serialization/test.proto\x12\x32ni.measurementlink.measurement.tests.serialization\x1a\x1dni/protobuf/types/array.proto\x1a\x1eni/protobuf/types/xydata.proto\"\x97\x07\n\x14MeasurementParameter\x12\x12\n\nfloat_data\x18\x01 \x01(\x02\x12\x13\n\x0b\x64ouble_data\x18\x02 \x01(\x01\x12\x12\n\nint32_data\x18\x03 \x01(\x05\x12\x13\n\x0buint32_data\x18\x04 \x01(\r\x12\x12\n\nint64_data\x18\x05 \x01(\x03\x12\x13\n\x0buint64_data\x18\x06 \x01(\x04\x12\x11\n\tbool_data\x18\x07 \x01(\x08\x12\x13\n\x0bstring_data\x18\x08 \x01(\t\x12\x19\n\x11\x64ouble_array_data\x18\t \x03(\x01\x12\x18\n\x10\x66loat_array_data\x18\n \x03(\x02\x12\x18\n\x10int32_array_data\x18\x0b \x03(\x05\x12\x19\n\x11uint32_array_data\x18\x0c \x03(\r\x12\x18\n\x10int64_array_data\x18\r \x03(\x03\x12\x19\n\x11uint64_array_data\x18\x0e \x03(\x04\x12\x17\n\x0f\x62ool_array_data\x18\x0f \x03(\x08\x12\x19\n\x11string_array_data\x18\x10 \x03(\t\x12U\n\tenum_data\x18\x11 \x01(\x0e\x32\x42.ni.measurementlink.measurement.tests.serialization.DifferentColor\x12[\n\x0f\x65num_array_data\x18\x12 \x03(\x0e\x32\x42.ni.measurementlink.measurement.tests.serialization.DifferentColor\x12T\n\rint_enum_data\x18\x13 \x01(\x0e\x32=.ni.measurementlink.measurement.tests.serialization.Countries\x12Z\n\x13int_enum_array_data\x18\x14 \x03(\x0e\x32=.ni.measurementlink.measurement.tests.serialization.Countries\x12\x30\n\x07xy_data\x18\x15 \x01(\x0b\x32\x1f.ni.protobuf.types.DoubleXYData\x12\x36\n\rxy_data_array\x18\x16 \x03(\x0b\x32\x1f.ni.protobuf.types.DoubleXYData\x12\x39\n\x0f\x64ouble_2d_array\x18\x17 \x01(\x0b\x32 .ni.protobuf.types.Double2DArray*=\n\x0e\x44ifferentColor\x12\n\n\x06PURPLE\x10\x00\x12\n\n\x06ORANGE\x10\x01\x12\x08\n\x04TEAL\x10\x02\x12\t\n\x05\x42ROWN\x10\x03*?\n\tCountries\x12\x0b\n\x07\x41MERICA\x10\x00\x12\n\n\x06TAIWAN\x10\x01\x12\r\n\tAUSTRALIA\x10\x02\x12\n\n\x06\x43\x41NADA\x10\x03\x62\x06proto3')
 
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, globals())
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'serialization.test_pb2', globals())
 if _descriptor._USE_C_DESCRIPTORS == False:
 
   DESCRIPTOR._options = None
-  _DIFFERENTCOLOR._serialized_start=975
-  _DIFFERENTCOLOR._serialized_end=1036
-  _COUNTRIES._serialized_start=1038
-  _COUNTRIES._serialized_end=1101
-  _MEASUREMENTPARAMETER._serialized_start=113
-  _MEASUREMENTPARAMETER._serialized_end=973
+  _DIFFERENTCOLOR._serialized_start=1065
+  _DIFFERENTCOLOR._serialized_end=1126
+  _COUNTRIES._serialized_start=1128
+  _COUNTRIES._serialized_end=1191
+  _MEASUREMENTPARAMETER._serialized_start=144
+  _MEASUREMENTPARAMETER._serialized_end=1063
 # @@protoc_insertion_point(module_scope)

--- a/packages/service/tests/utilities/stubs/serialization/test_pb2.pyi
+++ b/packages/service/tests/utilities/stubs/serialization/test_pb2.pyi
@@ -9,6 +9,7 @@ import google.protobuf.descriptor
 import google.protobuf.internal.containers
 import google.protobuf.internal.enum_type_wrapper
 import google.protobuf.message
+import ni_measurement_plugin_sdk_service._internal.stubs.ni.protobuf.types.array_pb2 as ni_protobuf_types_array_pb2
 import ni_measurement_plugin_sdk_service._internal.stubs.ni.protobuf.types.xydata_pb2 as ni_protobuf_types_xydata_pb2
 import sys
 import typing
@@ -84,6 +85,7 @@ class MeasurementParameter(google.protobuf.message.Message):
     INT_ENUM_ARRAY_DATA_FIELD_NUMBER: builtins.int
     XY_DATA_FIELD_NUMBER: builtins.int
     XY_DATA_ARRAY_FIELD_NUMBER: builtins.int
+    DOUBLE_2D_ARRAY_FIELD_NUMBER: builtins.int
     float_data: builtins.float
     double_data: builtins.float
     int32_data: builtins.int
@@ -118,6 +120,8 @@ class MeasurementParameter(google.protobuf.message.Message):
     def xy_data(self) -> ni_protobuf_types_xydata_pb2.DoubleXYData: ...
     @property
     def xy_data_array(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[ni_protobuf_types_xydata_pb2.DoubleXYData]: ...
+    @property
+    def double_2d_array(self) -> ni_protobuf_types_array_pb2.Double2DArray: ...
     def __init__(
         self,
         *,
@@ -143,8 +147,9 @@ class MeasurementParameter(google.protobuf.message.Message):
         int_enum_array_data: collections.abc.Iterable[global___Countries.ValueType] | None = ...,
         xy_data: ni_protobuf_types_xydata_pb2.DoubleXYData | None = ...,
         xy_data_array: collections.abc.Iterable[ni_protobuf_types_xydata_pb2.DoubleXYData] | None = ...,
+        double_2d_array: ni_protobuf_types_array_pb2.Double2DArray | None = ...,
     ) -> None: ...
-    def HasField(self, field_name: typing.Literal["xy_data", b"xy_data"]) -> builtins.bool: ...
-    def ClearField(self, field_name: typing.Literal["bool_array_data", b"bool_array_data", "bool_data", b"bool_data", "double_array_data", b"double_array_data", "double_data", b"double_data", "enum_array_data", b"enum_array_data", "enum_data", b"enum_data", "float_array_data", b"float_array_data", "float_data", b"float_data", "int32_array_data", b"int32_array_data", "int32_data", b"int32_data", "int64_array_data", b"int64_array_data", "int64_data", b"int64_data", "int_enum_array_data", b"int_enum_array_data", "int_enum_data", b"int_enum_data", "string_array_data", b"string_array_data", "string_data", b"string_data", "uint32_array_data", b"uint32_array_data", "uint32_data", b"uint32_data", "uint64_array_data", b"uint64_array_data", "uint64_data", b"uint64_data", "xy_data", b"xy_data", "xy_data_array", b"xy_data_array"]) -> None: ...
+    def HasField(self, field_name: typing.Literal["double_2d_array", b"double_2d_array", "xy_data", b"xy_data"]) -> builtins.bool: ...
+    def ClearField(self, field_name: typing.Literal["bool_array_data", b"bool_array_data", "bool_data", b"bool_data", "double_2d_array", b"double_2d_array", "double_array_data", b"double_array_data", "double_data", b"double_data", "enum_array_data", b"enum_array_data", "enum_data", b"enum_data", "float_array_data", b"float_array_data", "float_data", b"float_data", "int32_array_data", b"int32_array_data", "int32_data", b"int32_data", "int64_array_data", b"int64_array_data", "int64_data", b"int64_data", "int_enum_array_data", b"int_enum_array_data", "int_enum_data", b"int_enum_data", "string_array_data", b"string_array_data", "string_data", b"string_data", "uint32_array_data", b"uint32_array_data", "uint32_data", b"uint32_data", "uint64_array_data", b"uint64_array_data", "uint64_data", b"uint64_data", "xy_data", b"xy_data", "xy_data_array", b"xy_data_array"]) -> None: ...
 
 global___MeasurementParameter = MeasurementParameter


### PR DESCRIPTION
<!-- TODO: Check the below box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/measurement-plugin-python/blob/main/CONTRIBUTING.md) -->
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-plugin-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Adding Input Support for Measurment Client Generator and Service and updating Sample Measurement.

### Why should this Pull Request be merged?

Adding Input Support for Client Generator, Service and Sample Measurement

### What testing has been done?

- Automated tests are passing after adding Double2DArray Input parameter.
- Measurement is running fine through commandline.
- Tested on MeasurementUI Editor with Sample Measurement.