### PR TITLE
Update to latest ni-apis and add regenerated stubs for array.proto

### DIFF
--- a/packages/service/ni_measurement_plugin_sdk_service/_internal/stubs/ni/protobuf/types/array_pb2.py
+++ b/packages/service/ni_measurement_plugin_sdk_service/_internal/stubs/ni/protobuf/types/array_pb2.py
@@ -13,7 +13,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x1dni/protobuf/types/array.proto\x12\x11ni.protobuf.types\"<\n\rDouble2DArray\x12\x0c\n\x04rows\x18\x01 \x01(\x05\x12\x0f\n\x07\x63olumns\x18\x02 \x01(\x05\x12\x0c\n\x04\x64\x61ta\x18\x03 \x03(\x01\x42\x82\x01\n\x15\x63om.ni.protobuf.typesB\nArrayProtoP\x01Z\x05types\xa2\x02\x04NIPT\xaa\x02\"NationalInstruments.Protobuf.Types\xca\x02\x11NI\\PROTOBUF\\TYPES\xea\x02\x13NI::Protobuf::Typesb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x1dni/protobuf/types/array.proto\x12\x11ni.protobuf.types\"<\n\rDouble2DArray\x12\x0c\n\x04rows\x18\x01 \x01(\x05\x12\x0f\n\x07\x63olumns\x18\x02 \x01(\x05\x12\x0c\n\x04\x64\x61ta\x18\x03 \x03(\x01\"<\n\rString2DArray\x12\x0c\n\x04rows\x18\x01 \x01(\x05\x12\x0f\n\x07\x63olumns\x18\x02 \x01(\x05\x12\x0c\n\x04\x64\x61ta\x18\x03 \x03(\tB\x82\x01\n\x15\x63om.ni.protobuf.typesB\nArrayProtoP\x01Z\x05types\xa2\x02\x04NIPT\xaa\x02\"NationalInstruments.Protobuf.Types\xca\x02\x11NI\\PROTOBUF\\TYPES\xea\x02\x13NI::Protobuf::Typesb\x06proto3')
 
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, globals())
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'ni.protobuf.types.array_pb2', globals())
@@ -23,4 +23,6 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   DESCRIPTOR._serialized_options = b'\n\025com.ni.protobuf.typesB\nArrayProtoP\001Z\005types\242\002\004NIPT\252\002\"NationalInstruments.Protobuf.Types\312\002\021NI\\PROTOBUF\\TYPES\352\002\023NI::Protobuf::Types'
   _DOUBLE2DARRAY._serialized_start=52
   _DOUBLE2DARRAY._serialized_end=112
+  _STRING2DARRAY._serialized_start=114
+  _STRING2DARRAY._serialized_end=174
 # @@protoc_insertion_point(module_scope)

--- a/packages/service/ni_measurement_plugin_sdk_service/_internal/stubs/ni/protobuf/types/array_pb2.pyi
+++ b/packages/service/ni_measurement_plugin_sdk_service/_internal/stubs/ni/protobuf/types/array_pb2.pyi
@@ -17,11 +17,12 @@ DESCRIPTOR: google.protobuf.descriptor.FileDescriptor
 @typing.final
 class Double2DArray(google.protobuf.message.Message):
     """---------------------------------------------------------------------
-    Defines a 2D array of double values. The 2D array is stored as
-    a repeated double, a 1D array. It is stored in row major order.
+    Defines a 2D array of values. The 2D array is stored as a repeated field of
+    the appropriate element type, a 1D array. It is stored in row major order.
 
     Example:
     Repeated Double: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+
     rows: 2
     columns: 5
 
@@ -59,3 +60,25 @@ class Double2DArray(google.protobuf.message.Message):
     def ClearField(self, field_name: typing.Literal["columns", b"columns", "data", b"data", "rows", b"rows"]) -> None: ...
 
 global___Double2DArray = Double2DArray
+
+@typing.final
+class String2DArray(google.protobuf.message.Message):
+    DESCRIPTOR: google.protobuf.descriptor.Descriptor
+
+    ROWS_FIELD_NUMBER: builtins.int
+    COLUMNS_FIELD_NUMBER: builtins.int
+    DATA_FIELD_NUMBER: builtins.int
+    rows: builtins.int
+    columns: builtins.int
+    @property
+    def data(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[builtins.str]: ...
+    def __init__(
+        self,
+        *,
+        rows: builtins.int = ...,
+        columns: builtins.int = ...,
+        data: collections.abc.Iterable[builtins.str] | None = ...,
+    ) -> None: ...
+    def ClearField(self, field_name: typing.Literal["columns", b"columns", "data", b"data", "rows", b"rows"]) -> None: ...
+
+global___String2DArray = String2DArray


### PR DESCRIPTION
<!-- TODO: Check the below box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/measurement-plugin-python/blob/main/CONTRIBUTING.md) -->
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-plugin-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Array.proto was recently updated in [ni-apis](https://github.com/ni/ni-apis/pull/77). We want update it for adding String2DArray support.

### Why should this Pull Request be merged?

Access to array.proto gRPC message types.

### What testing has been done?

None. PR build should be sufficient.