### PR TITLE
Allow default arguments to be used for measure() method

### DIFF
--- a/packages/service/ni_measurement_plugin_sdk_service/_internal/grpc_servicer.py
+++ b/packages/service/ni_measurement_plugin_sdk_service/_internal/grpc_servicer.py
@@ -134,7 +134,8 @@ def _get_mapping_by_parameter_name(
     signature = inspect.signature(measure_function)
     mapping_by_variable_name = {}
     for i, parameter in enumerate(signature.parameters.values(), start=1):
-        mapping_by_variable_name[parameter.name] = mapping_by_id[i]
+        if i in mapping_by_id:
+            mapping_by_variable_name[parameter.name] = mapping_by_id[i]
     return mapping_by_variable_name
 
 


### PR DESCRIPTION
I want this to work (default parameter value):

```python
@measurementservice.output("my_output", nims.DataType.Double)
@measurementservice.configuration("my_param_1", nims.DataType.Double)
#@measurementservice.configuration("my_param_2_still_debugging_might_not_use_this", nims.DataType.Double)
def measure(my_param_1,
            my_param_2_still_debugging_might_not_use_this = None):
    return (0.0,)
```

<!-- TODO: Check the below box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/measurement-plugin-python/blob/main/CONTRIBUTING.md) -->
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-plugin-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Allows default parameters to be used from the `measure()` method for the measurement plugin instead of throwing an exception.

Currently, the above plugin script will throw an exception (and not a particularly helpful one):
> 2025-02-26 14:35:42,820 ERROR: Exception iterating responses: 2
Traceback (most recent call last):
  File ".venv\Lib\site-packages\grpc\_server.py", line 654, in _take_response_from_response_iterator
    return next(response_iterator), True
           ^^^^^^^^^^^^^^^^^^^^^^^
  File ".venv\Lib\site-packages\ni_measurement_plugin_sdk_service\grpc\loggers.py", line 391, in __next__
    response = next(self._inner_iterator)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".venv\Lib\site-packages\ni_measurement_plugin_sdk_service\_internal\grpc_servicer.py", line 381, in Measure
    mapping_by_variable_name = _get_mapping_by_parameter_name(
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".venv\Lib\site-packages\ni_measurement_plugin_sdk_service\_internal\grpc_servicer.py", line 139, in _get_mapping_by_parameter_name
    mapping_by_variable_name[parameter.name] = mapping_by_id[i]
                                               ~~~~~~~~~~~~~^^^
KeyError: 2

### Why should this Pull Request be merged?

This problem is admittedly easy to workaround (comment out both the `@measurementservice.configuration()` AND the method parameter), but this fixes a corner case that really doesn't have to error -- and it makes the exception that gets thrown when there is no default much better .

### What testing has been done?

My measurement plugin works and uses default parameters for any arguments that weren't specified with `@measurementservice.configuration()`.

Also tested that any arguments **without** a default parameter that also weren't configured with `@measurementservice.configuration()` does cause an exception to be thrown -- and the exception is more useful:

> 2025-02-26 14:23:23,980 ERROR: Exception iterating responses: measure() missing 1 required positional argument: 'my_param_2_still_debugging_might_not_use_this'