### PR TITLE
Remove support for Python 3.8

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest]
-        python-version: [3.8, 3.9, '3.10', 3.11, 3.12]
+        python-version: [3.9, '3.10', 3.11, 3.12]
       # Fail-fast skews the pass/fail ratio and seems to make pytest produce
       # incomplete JUnit XML results.
       fail-fast: false

--- a/examples/game_of_life/pyproject.toml
+++ b/examples/game_of_life/pyproject.toml
@@ -6,7 +6,7 @@ description = "Measurement plug-in example that displays Conway's Game of Life i
 authors = ["National Instruments"]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 ni-measurement-plugin-sdk-service = {version = "^2.2.0"}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 

--- a/examples/nidaqmx_analog_input/pyproject.toml
+++ b/examples/nidaqmx_analog_input/pyproject.toml
@@ -6,7 +6,7 @@ description = "Measurement plug-in example that performs a finite analog input m
 authors = ["National Instruments"]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 nidaqmx = { version = ">=0.8.0", extras = ["grpc"] }
 ni-measurement-plugin-sdk-service = {version = "^2.2.0"}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558

--- a/examples/nidcpower_source_dc_voltage/pyproject.toml
+++ b/examples/nidcpower_source_dc_voltage/pyproject.toml
@@ -6,7 +6,7 @@ description = "Measurement plug-in example that sources and measures a DC voltag
 authors = ["National Instruments"]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 nidcpower = { version = ">=1.4.4", extras = ["grpc"] }
 ni-measurement-plugin-sdk-service = {version = "^2.2.0"}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558

--- a/examples/nidcpower_source_dc_voltage_with_multiplexer/pyproject.toml
+++ b/examples/nidcpower_source_dc_voltage_with_multiplexer/pyproject.toml
@@ -6,7 +6,7 @@ description = "Measurement plug-in example that sources and measures a DC voltag
 authors = ["National Instruments"]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 nidcpower = { version = ">=1.4.4", extras = ["grpc"] }
 niswitch = { version = ">=1.4.4", extras = ["grpc"] }
 ni-measurement-plugin-sdk-service = {version = "^2.2.0"}

--- a/examples/nidigital_spi/pyproject.toml
+++ b/examples/nidigital_spi/pyproject.toml
@@ -6,7 +6,7 @@ description = "Measurement plug-in example that tests a SPI device using an NI D
 authors = ["National Instruments"]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 nidigital = { version = ">=1.4.4", extras = ["grpc"] }
 ni-measurement-plugin-sdk-service = {version = "^2.2.0"}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558

--- a/examples/nidmm_measurement/pyproject.toml
+++ b/examples/nidmm_measurement/pyproject.toml
@@ -6,7 +6,7 @@ description = "Measurement plug-in example that performs a measurement using an 
 authors = ["National Instruments"]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 nidmm = { version = ">=1.4.4", extras = ["grpc"] }
 ni-measurement-plugin-sdk-service = {version = "^2.2.0"}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558

--- a/examples/nifgen_standard_function/pyproject.toml
+++ b/examples/nifgen_standard_function/pyproject.toml
@@ -6,7 +6,7 @@ description = "Measurement plug-in example that generates a standard function wa
 authors = ["National Instruments"]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 nifgen = { version = ">=1.4.4", extras = ["grpc"] }
 ni-measurement-plugin-sdk-service = {version = "^2.2.0"}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558

--- a/examples/niscope_acquire_waveform/pyproject.toml
+++ b/examples/niscope_acquire_waveform/pyproject.toml
@@ -6,7 +6,7 @@ description = "Measurement plug-in example that acquires a waveform using an NI 
 authors = ["National Instruments"]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 niscope = { version = ">=1.4.4", extras = ["grpc"] }
 ni-measurement-plugin-sdk-service = {version = "^2.2.0"}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558

--- a/examples/niswitch_control_relays/pyproject.toml
+++ b/examples/niswitch_control_relays/pyproject.toml
@@ -6,7 +6,7 @@ description = "Measurement plug-in example that controls relays using an NI rela
 authors = ["National Instruments"]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 niswitch = { version = ">=1.4.4", extras = ["grpc"] }
 ni-measurement-plugin-sdk-service = {version = "^2.2.0"}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558

--- a/examples/nivisa_dmm_measurement/pyproject.toml
+++ b/examples/nivisa_dmm_measurement/pyproject.toml
@@ -6,7 +6,7 @@ description = "Measurement plug-in example that performs a DMM measurement using
 authors = ["National Instruments"]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 ni-measurement-plugin-sdk-service = {version = "^2.2.0"}
 PyVISA = "^1.13.0"
 PyVISA-sim = "^0.5.1"

--- a/examples/output_voltage_measurement/measurement.py
+++ b/examples/output_voltage_measurement/measurement.py
@@ -1,4 +1,4 @@
-""" Source DC voltage as input with an NI SMU and measure output using NI-VISA DMM."""
+"""Source DC voltage as input with an NI SMU and measure output using NI-VISA DMM."""
 
 import logging
 import pathlib

--- a/examples/output_voltage_measurement/pyproject.toml
+++ b/examples/output_voltage_measurement/pyproject.toml
@@ -6,7 +6,7 @@ description = ""
 authors = ["National Instruments"]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 ni-measurement-plugin-sdk-service = {version = "^2.2.0"}
 PyVISA = "^1.13.0"
 PyVISA-sim = "^0.5.1"

--- a/examples/sample_measurement/pyproject.toml
+++ b/examples/sample_measurement/pyproject.toml
@@ -6,7 +6,7 @@ description = "Measurement plug-in example that performs a loopback measurement 
 authors = ["National Instruments"]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 ni-measurement-plugin-sdk-service = {version = "^2.3.0-dev0", allow-prereleases = true}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 

--- a/packages/generator/README.md
+++ b/packages/generator/README.md
@@ -22,7 +22,7 @@ Measurement Plug-In SDK Generator for Python (`ni-measurement-plugin-sdk-generat
 
 ## Dependencies
 
-- Python >= 3.8 [(3.9 recommended)](https://www.python.org/downloads/release/python-3913/)
+- [Python >= 3.9](https://www.python.org/downloads/release/python-3913/)
 - [mako >= 1.2.1, < 2.x](https://pypi.org/project/Mako/1.2.1/)
 - [click >= 8.1.3](https://pypi.org/project/click/8.1.3/)
 

--- a/packages/generator/ni_measurement_plugin_sdk_generator/client/_support.py
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/client/_support.py
@@ -4,7 +4,6 @@ import json
 import keyword
 import pathlib
 import re
-import sys
 from enum import Enum
 from typing import AbstractSet, Dict, Iterable, List, Optional, Tuple, Type, TypeVar
 
@@ -455,10 +454,7 @@ def _remove_suffix(string: str) -> str:
     suffixes = ["_Python", "_LabVIEW", "_NET"]
     for suffix in suffixes:
         if string.endswith(suffix):
-            if sys.version_info >= (3, 9):
-                return string.removesuffix(suffix)
-            else:
-                return string[0 : len(string) - len(suffix)]
+            return string.removesuffix(suffix)
     return string
 
 

--- a/packages/generator/poetry.lock
+++ b/packages/generator/poetry.lock
@@ -817,7 +817,7 @@ name = "ni-measurement-plugin-sdk-service"
 version = "2.3.0-dev0"
 description = "Measurement Plug-In Support for Python"
 optional = false
-python-versions = "^3.8"
+python-versions = "^3.9"
 files = []
 develop = true
 
@@ -827,7 +827,7 @@ grpcio = "^1.49.1"
 protobuf = "^4.21"
 python-decouple = ">=3.8"
 pywin32 = {version = ">=303", markers = "sys_platform == \"win32\""}
-traceloggingdynamic = {version = ">=1.0", markers = "python_version >= \"3.9\" and python_version < \"4.0\" and sys_platform == \"win32\""}
+traceloggingdynamic = {version = ">=1.0", markers = "sys_platform == \"win32\""}
 
 [package.extras]
 drivers = ["nidaqmx[grpc] (>=0.8.0)", "nidcpower[grpc] (>=1.4.4)", "nidigital[grpc] (>=1.4.4)", "nidmm[grpc] (>=1.4.4)", "nifgen[grpc] (>=1.4.4)", "niscope[grpc] (>=1.4.4)", "niswitch[grpc] (>=1.4.4)"]
@@ -1405,5 +1405,5 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.8"
-content-hash = "61a4cc20f91788a0fb43d1210684c723dbe45d1f3ef638675ec2be875981dcd7"
+python-versions = "^3.9"
+content-hash = "12968f137c7ba8fea4a180a71eedd0c9dfc9c0f508fa5f6b45b842b3711d748a"

--- a/packages/generator/pyproject.toml
+++ b/packages/generator/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 Mako = "^1.2.1"
 click = ">=8.1.3"
 grpcio = "^1.49.1"
@@ -42,7 +42,7 @@ ni-measurement-plugin-sdk-service = {path = "../../packages/service", develop = 
 bandit = { version = ">=1.7", extras = ["toml"] }
 tox = ">=4.0"
 grpcio-tools = [
-  {version = "1.49.1", python = ">=3.8,<3.12"},
+  {version = "1.49.1", python = ">=3.9,<3.12"},
   {version = "1.59.0", python = "^3.12"},
 ]
 

--- a/packages/generator/tox.ini
+++ b/packages/generator/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 isolated_build = true
-envlist = clean, py{38,39,310,311,312}
+envlist = clean, py{39,310,311,312}
 
 [testenv]
 skip_install = true

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -16,7 +16,7 @@ For installation and usage, see [Measurement Plug-In SDK Service for Python (`ni
 
 ## Dependencies
 
-- Python >= 3.8 [(3.9 recommended)](https://www.python.org/downloads/release/python-3913/)
+- [Python >= 3.9](https://www.python.org/downloads/release/python-3913/)
 - [mako >= 1.2.1, < 2.x](https://pypi.org/project/Mako/1.2.1/)
 - [click >= 8.1.3](https://pypi.org/project/click/8.1.3/)
 

--- a/packages/sdk/poetry.lock
+++ b/packages/sdk/poetry.lock
@@ -275,7 +275,7 @@ name = "ni-measurement-plugin-sdk-generator"
 version = "2.3.0-dev0"
 description = "Measurement Plug-In Code Generator for Python"
 optional = false
-python-versions = "^3.8"
+python-versions = "^3.9"
 files = []
 develop = true
 
@@ -297,7 +297,7 @@ name = "ni-measurement-plugin-sdk-service"
 version = "2.3.0-dev0"
 description = "Measurement Plug-In Support for Python"
 optional = false
-python-versions = "^3.8"
+python-versions = "^3.9"
 files = []
 develop = true
 
@@ -307,7 +307,7 @@ grpcio = "^1.49.1"
 protobuf = "^4.21"
 python-decouple = ">=3.8"
 pywin32 = {version = ">=303", markers = "sys_platform == \"win32\""}
-traceloggingdynamic = {version = ">=1.0", markers = "python_version >= \"3.9\" and python_version < \"4.0\" and sys_platform == \"win32\""}
+traceloggingdynamic = {version = ">=1.0", markers = "sys_platform == \"win32\""}
 
 [package.extras]
 drivers = ["nidaqmx[grpc] (>=0.8.0)", "nidcpower[grpc] (>=1.4.4)", "nidigital[grpc] (>=1.4.4)", "nidmm[grpc] (>=1.4.4)", "nifgen[grpc] (>=1.4.4)", "niscope[grpc] (>=1.4.4)", "niswitch[grpc] (>=1.4.4)"]
@@ -483,5 +483,5 @@ files = [
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.8"
-content-hash = "9f4bd46b62519d49d8b94ed65a50b259c5a89567266c6ea1a01a9bf11bdff33c"
+python-versions = "^3.9"
+content-hash = "f5db3a791370916e1f5ad48db61b5418385b0c2cd8c429350e71cae8f434c6f1"

--- a/packages/sdk/pyproject.toml
+++ b/packages/sdk/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 ni-measurement-plugin-sdk-service = "*"
 ni-measurement-plugin-sdk-generator = "*"
 

--- a/packages/service/README.md
+++ b/packages/service/README.md
@@ -34,9 +34,9 @@ InstrumentStudio and automated testing in TestStand.
 
 ## Dependencies
 
-- Python >= 3.8 [(3.9 recommended)](https://www.python.org/downloads/release/python-3913/)
+- [Python >= 3.9](https://www.python.org/downloads/release/python-3913/)
 - [grpcio >= 1.49.1, < 2.x](https://pypi.org/project/grpcio/1.49.1/)
-- [protobuf >= 4.21, < 5.x](https://pypi.org/project/protobuf/4.21.0/)
+- [protobuf >= 4.21](https://pypi.org/project/protobuf/4.21.0/)
 - [pywin32 >= 303 (Only for Windows)](https://pypi.org/project/pywin32/303/)
 
 ---

--- a/packages/service/ni_measurement_plugin_sdk_service/_dotenvpath.py
+++ b/packages/service/ni_measurement_plugin_sdk_service/_dotenvpath.py
@@ -1,7 +1,7 @@
 import inspect
 import sys
 import traceback
-from pathlib import Path, PurePath
+from pathlib import Path
 from typing import Optional
 
 

--- a/packages/service/ni_measurement_plugin_sdk_service/_dotenvpath.py
+++ b/packages/service/ni_measurement_plugin_sdk_service/_dotenvpath.py
@@ -44,7 +44,7 @@ def _get_caller_path() -> Optional[Path]:
     for frame, _ in traceback.walk_stack(inspect.currentframe()):
         if frame.f_code.co_filename:
             module_path = Path(frame.f_code.co_filename)
-            if _exists(module_path) and not _is_relative_to(module_path, nims_path):
+            if _exists(module_path) and not module_path.is_relative_to(nims_path):
                 return module_path
 
     return None
@@ -63,21 +63,6 @@ else:
         import os
 
         return os.path.exists(path)
-
-
-if sys.version_info >= (3, 9):
-
-    def _is_relative_to(path: PurePath, other: PurePath) -> bool:
-        return path.is_relative_to(other)
-
-else:
-
-    def _is_relative_to(path: PurePath, other: PurePath) -> bool:
-        try:
-            _ = path.relative_to(other)
-            return True
-        except ValueError:
-            return False
 
 
 def _get_nims_path() -> Path:

--- a/packages/service/poetry.lock
+++ b/packages/service/poetry.lock
@@ -2,17 +2,6 @@
 
 [[package]]
 name = "alabaster"
-version = "0.7.13"
-description = "A configurable sidebar-enabled Sphinx theme"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "alabaster-0.7.13-py3-none-any.whl", hash = "sha256:1ee19aca801bbabb5ba3f5f258e4422dfa86f82f3e9cefb0859b283cdd7f62a3"},
-    {file = "alabaster-0.7.13.tar.gz", hash = "sha256:a27a4a084d5e690e16e01e03ad2b2e552c61a65469419b907243193de1a84ae2"},
-]
-
-[[package]]
-name = "alabaster"
 version = "0.7.16"
 description = "A light, configurable Sphinx theme"
 optional = false
@@ -21,20 +10,6 @@ files = [
     {file = "alabaster-0.7.16-py3-none-any.whl", hash = "sha256:b46733c07dce03ae4e150330b975c75737fa60f0a7c591b6c8bf4928a28e2c92"},
     {file = "alabaster-0.7.16.tar.gz", hash = "sha256:75a8b99c28a5dad50dd7f8ccdd447a121ddb3892da9e53d1ca5cca3106d58d65"},
 ]
-
-[[package]]
-name = "astroid"
-version = "3.2.4"
-description = "An abstract syntax tree for Python with inference support."
-optional = false
-python-versions = ">=3.8.0"
-files = [
-    {file = "astroid-3.2.4-py3-none-any.whl", hash = "sha256:413658a61eeca6202a59231abb473f932038fbcbf1666587f66d482083413a25"},
-    {file = "astroid-3.2.4.tar.gz", hash = "sha256:0e14202810b30da1b735827f78f5157be2bbd4a7a59b7707ca0bfc2fb4c0063a"},
-]
-
-[package.dependencies]
-typing-extensions = {version = ">=4.0.0", markers = "python_version < \"3.11\""}
 
 [[package]]
 name = "astroid"
@@ -47,6 +22,9 @@ files = [
     {file = "astroid-3.3.8.tar.gz", hash = "sha256:a88c7994f914a4ea8572fac479459f4955eeccc877be3f2d959a33273b0cf40b"},
 ]
 
+[package.dependencies]
+typing-extensions = {version = ">=4.0.0", markers = "python_version < \"3.11\""}
+
 [[package]]
 name = "babel"
 version = "2.17.0"
@@ -58,39 +36,8 @@ files = [
     {file = "babel-2.17.0.tar.gz", hash = "sha256:0c54cffb19f690cdcc52a3b50bcbf71e07a808d1c80d549f2459b9d2cf0afb9d"},
 ]
 
-[package.dependencies]
-pytz = {version = ">=2015.7", markers = "python_version < \"3.9\""}
-
 [package.extras]
 dev = ["backports.zoneinfo", "freezegun (>=1.0,<2.0)", "jinja2 (>=3.0)", "pytest (>=6.0)", "pytest-cov", "pytz", "setuptools", "tzdata"]
-
-[[package]]
-name = "backports-zoneinfo"
-version = "0.2.1"
-description = "Backport of the standard library zoneinfo module"
-optional = true
-python-versions = ">=3.6"
-files = [
-    {file = "backports.zoneinfo-0.2.1-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:da6013fd84a690242c310d77ddb8441a559e9cb3d3d59ebac9aca1a57b2e18bc"},
-    {file = "backports.zoneinfo-0.2.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:89a48c0d158a3cc3f654da4c2de1ceba85263fafb861b98b59040a5086259722"},
-    {file = "backports.zoneinfo-0.2.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:1c5742112073a563c81f786e77514969acb58649bcdf6cdf0b4ed31a348d4546"},
-    {file = "backports.zoneinfo-0.2.1-cp36-cp36m-win32.whl", hash = "sha256:e8236383a20872c0cdf5a62b554b27538db7fa1bbec52429d8d106effbaeca08"},
-    {file = "backports.zoneinfo-0.2.1-cp36-cp36m-win_amd64.whl", hash = "sha256:8439c030a11780786a2002261569bdf362264f605dfa4d65090b64b05c9f79a7"},
-    {file = "backports.zoneinfo-0.2.1-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:f04e857b59d9d1ccc39ce2da1021d196e47234873820cbeaad210724b1ee28ac"},
-    {file = "backports.zoneinfo-0.2.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:17746bd546106fa389c51dbea67c8b7c8f0d14b5526a579ca6ccf5ed72c526cf"},
-    {file = "backports.zoneinfo-0.2.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:5c144945a7752ca544b4b78c8c41544cdfaf9786f25fe5ffb10e838e19a27570"},
-    {file = "backports.zoneinfo-0.2.1-cp37-cp37m-win32.whl", hash = "sha256:e55b384612d93be96506932a786bbcde5a2db7a9e6a4bb4bffe8b733f5b9036b"},
-    {file = "backports.zoneinfo-0.2.1-cp37-cp37m-win_amd64.whl", hash = "sha256:a76b38c52400b762e48131494ba26be363491ac4f9a04c1b7e92483d169f6582"},
-    {file = "backports.zoneinfo-0.2.1-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:8961c0f32cd0336fb8e8ead11a1f8cd99ec07145ec2931122faaac1c8f7fd987"},
-    {file = "backports.zoneinfo-0.2.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:e81b76cace8eda1fca50e345242ba977f9be6ae3945af8d46326d776b4cf78d1"},
-    {file = "backports.zoneinfo-0.2.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7b0a64cda4145548fed9efc10322770f929b944ce5cee6c0dfe0c87bf4c0c8c9"},
-    {file = "backports.zoneinfo-0.2.1-cp38-cp38-win32.whl", hash = "sha256:1b13e654a55cd45672cb54ed12148cd33628f672548f373963b0bff67b217328"},
-    {file = "backports.zoneinfo-0.2.1-cp38-cp38-win_amd64.whl", hash = "sha256:4a0f800587060bf8880f954dbef70de6c11bbe59c673c3d818921f042f9954a6"},
-    {file = "backports.zoneinfo-0.2.1.tar.gz", hash = "sha256:fadbfe37f74051d024037f223b8e001611eac868b5c5b06144ef4d8b799862f2"},
-]
-
-[package.extras]
-tzdata = ["tzdata"]
 
 [[package]]
 name = "bandit"
@@ -809,29 +756,6 @@ files = [
     {file = "imagesize-1.4.1-py2.py3-none-any.whl", hash = "sha256:0d8d18d08f840c19d0ee7ca1fd82490fdc3729b7ac93f49870406ddde8ef8d8b"},
     {file = "imagesize-1.4.1.tar.gz", hash = "sha256:69150444affb9cb0d5cc5a92b3676f0b2fb7cd9ae39e947a5e11a36b4497cd4a"},
 ]
-
-[[package]]
-name = "importlib-metadata"
-version = "8.5.0"
-description = "Read metadata from Python packages"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "importlib_metadata-8.5.0-py3-none-any.whl", hash = "sha256:45e54197d28b7a7f1559e60b95e7c567032b602131fbd588f1497f47880aa68b"},
-    {file = "importlib_metadata-8.5.0.tar.gz", hash = "sha256:71522656f0abace1d072b9e5481a48f07c138e00f079c38c8f883823f9c26bd7"},
-]
-
-[package.dependencies]
-zipp = ">=3.20"
-
-[package.extras]
-check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1)"]
-cover = ["pytest-cov"]
-doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-enabler = ["pytest-enabler (>=2.2)"]
-perf = ["ipython"]
-test = ["flufl.flake8", "importlib-resources (>=1.3)", "jaraco.test (>=5.4)", "packaging", "pyfakefs", "pytest (>=6,!=8.1.*)", "pytest-perf (>=0.9.2)"]
-type = ["pytest-mypy"]
 
 [[package]]
 name = "importlib-metadata"
@@ -1704,17 +1628,6 @@ files = [
 ]
 
 [[package]]
-name = "pytz"
-version = "2025.1"
-description = "World timezone definitions, modern and historical"
-optional = false
-python-versions = "*"
-files = [
-    {file = "pytz-2025.1-py2.py3-none-any.whl", hash = "sha256:89dd22dca55b46eac6eda23b2d72721bf1bdfef212645d81513ef5d03038de57"},
-    {file = "pytz-2025.1.tar.gz", hash = "sha256:c2db42be2a2518b28e65f9207c4d05e6ff547d1efa4086469ef855e4ab70178e"},
-]
-
-[[package]]
 name = "pywin32"
 version = "308"
 description = "Python for Window Extensions"
@@ -1876,41 +1789,6 @@ files = [
 
 [[package]]
 name = "sphinx"
-version = "7.1.2"
-description = "Python documentation generator"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "sphinx-7.1.2-py3-none-any.whl", hash = "sha256:d170a81825b2fcacb6dfd5a0d7f578a053e45d3f2b153fecc948c37344eb4cbe"},
-    {file = "sphinx-7.1.2.tar.gz", hash = "sha256:780f4d32f1d7d1126576e0e5ecc19dc32ab76cd24e950228dcf7b1f6d3d9e22f"},
-]
-
-[package.dependencies]
-alabaster = ">=0.7,<0.8"
-babel = ">=2.9"
-colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
-docutils = ">=0.18.1,<0.21"
-imagesize = ">=1.3"
-importlib-metadata = {version = ">=4.8", markers = "python_version < \"3.10\""}
-Jinja2 = ">=3.0"
-packaging = ">=21.0"
-Pygments = ">=2.13"
-requests = ">=2.25.0"
-snowballstemmer = ">=2.0"
-sphinxcontrib-applehelp = "*"
-sphinxcontrib-devhelp = "*"
-sphinxcontrib-htmlhelp = ">=2.0.0"
-sphinxcontrib-jsmath = "*"
-sphinxcontrib-qthelp = "*"
-sphinxcontrib-serializinghtml = ">=1.1.5"
-
-[package.extras]
-docs = ["sphinxcontrib-websupport"]
-lint = ["docutils-stubs", "flake8 (>=3.5.0)", "flake8-simplify", "isort", "mypy (>=0.990)", "ruff", "sphinx-lint", "types-requests"]
-test = ["cython", "filelock", "html5lib", "pytest (>=4.6)"]
-
-[[package]]
-name = "sphinx"
 version = "7.4.7"
 description = "Python documentation generator"
 optional = false
@@ -2003,21 +1881,6 @@ dev = ["bump2version", "transifex-client", "twine", "wheel"]
 
 [[package]]
 name = "sphinxcontrib-applehelp"
-version = "1.0.4"
-description = "sphinxcontrib-applehelp is a Sphinx extension which outputs Apple help books"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "sphinxcontrib-applehelp-1.0.4.tar.gz", hash = "sha256:828f867945bbe39817c210a1abfd1bc4895c8b73fcaade56d45357a348a07d7e"},
-    {file = "sphinxcontrib_applehelp-1.0.4-py3-none-any.whl", hash = "sha256:29d341f67fb0f6f586b23ad80e072c8e6ad0b48417db2bde114a4c9746feb228"},
-]
-
-[package.extras]
-lint = ["docutils-stubs", "flake8", "mypy"]
-test = ["pytest"]
-
-[[package]]
-name = "sphinxcontrib-applehelp"
 version = "2.0.0"
 description = "sphinxcontrib-applehelp is a Sphinx extension which outputs Apple help books"
 optional = false
@@ -2030,21 +1893,6 @@ files = [
 [package.extras]
 lint = ["mypy", "ruff (==0.5.5)", "types-docutils"]
 standalone = ["Sphinx (>=5)"]
-test = ["pytest"]
-
-[[package]]
-name = "sphinxcontrib-devhelp"
-version = "1.0.2"
-description = "sphinxcontrib-devhelp is a sphinx extension which outputs Devhelp document."
-optional = false
-python-versions = ">=3.5"
-files = [
-    {file = "sphinxcontrib-devhelp-1.0.2.tar.gz", hash = "sha256:ff7f1afa7b9642e7060379360a67e9c41e8f3121f2ce9164266f61b9f4b338e4"},
-    {file = "sphinxcontrib_devhelp-1.0.2-py2.py3-none-any.whl", hash = "sha256:8165223f9a335cc1af7ffe1ed31d2871f325254c0423bc0c4c7cd1c1e4734a2e"},
-]
-
-[package.extras]
-lint = ["docutils-stubs", "flake8", "mypy"]
 test = ["pytest"]
 
 [[package]]
@@ -2062,21 +1910,6 @@ files = [
 lint = ["mypy", "ruff (==0.5.5)", "types-docutils"]
 standalone = ["Sphinx (>=5)"]
 test = ["pytest"]
-
-[[package]]
-name = "sphinxcontrib-htmlhelp"
-version = "2.0.1"
-description = "sphinxcontrib-htmlhelp is a sphinx extension which renders HTML help files"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "sphinxcontrib-htmlhelp-2.0.1.tar.gz", hash = "sha256:0cbdd302815330058422b98a113195c9249825d681e18f11e8b1f78a2f11efff"},
-    {file = "sphinxcontrib_htmlhelp-2.0.1-py3-none-any.whl", hash = "sha256:c38cb46dccf316c79de6e5515e1770414b797162b23cd3d06e67020e1d2a6903"},
-]
-
-[package.extras]
-lint = ["docutils-stubs", "flake8", "mypy"]
-test = ["html5lib", "pytest"]
 
 [[package]]
 name = "sphinxcontrib-htmlhelp"
@@ -2124,21 +1957,6 @@ test = ["flake8", "mypy", "pytest"]
 
 [[package]]
 name = "sphinxcontrib-qthelp"
-version = "1.0.3"
-description = "sphinxcontrib-qthelp is a sphinx extension which outputs QtHelp document."
-optional = false
-python-versions = ">=3.5"
-files = [
-    {file = "sphinxcontrib-qthelp-1.0.3.tar.gz", hash = "sha256:4c33767ee058b70dba89a6fc5c1892c0d57a54be67ddd3e7875a18d14cba5a72"},
-    {file = "sphinxcontrib_qthelp-1.0.3-py2.py3-none-any.whl", hash = "sha256:bd9fc24bcb748a8d51fd4ecaade681350aa63009a347a8c14e637895444dfab6"},
-]
-
-[package.extras]
-lint = ["docutils-stubs", "flake8", "mypy"]
-test = ["pytest"]
-
-[[package]]
-name = "sphinxcontrib-qthelp"
 version = "2.0.0"
 description = "sphinxcontrib-qthelp is a sphinx extension which outputs QtHelp documents"
 optional = false
@@ -2152,21 +1970,6 @@ files = [
 lint = ["mypy", "ruff (==0.5.5)", "types-docutils"]
 standalone = ["Sphinx (>=5)"]
 test = ["defusedxml (>=0.7.1)", "pytest"]
-
-[[package]]
-name = "sphinxcontrib-serializinghtml"
-version = "1.1.5"
-description = "sphinxcontrib-serializinghtml is a sphinx extension which outputs \"serialized\" HTML files (json and pickle)."
-optional = false
-python-versions = ">=3.5"
-files = [
-    {file = "sphinxcontrib-serializinghtml-1.1.5.tar.gz", hash = "sha256:aa5f6de5dfdf809ef505c4895e51ef5c9eac17d0f287933eb49ec495280b6952"},
-    {file = "sphinxcontrib_serializinghtml-1.1.5-py2.py3-none-any.whl", hash = "sha256:352a9a00ae864471d3a7ead8d7d79f5fc0b57e8b3f95e9867eb9eb28999b92fd"},
-]
-
-[package.extras]
-lint = ["docutils-stubs", "flake8", "mypy"]
-test = ["pytest"]
 
 [[package]]
 name = "sphinxcontrib-serializinghtml"
@@ -2394,7 +2197,6 @@ files = [
 ]
 
 [package.dependencies]
-"backports.zoneinfo" = {version = "*", markers = "python_version < \"3.9\""}
 tzdata = {version = "*", markers = "platform_system == \"Windows\""}
 
 [package.extras]
@@ -2439,25 +2241,6 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 
 [[package]]
 name = "zipp"
-version = "3.20.2"
-description = "Backport of pathlib-compatible object wrapper for zip files"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "zipp-3.20.2-py3-none-any.whl", hash = "sha256:a817ac80d6cf4b23bf7f2828b7cabf326f15a001bea8b1f9b49631780ba28350"},
-    {file = "zipp-3.20.2.tar.gz", hash = "sha256:bc9eb26f4506fda01b81bcde0ca78103b6e62f991b381fec825435c836edbc29"},
-]
-
-[package.extras]
-check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1)"]
-cover = ["pytest-cov"]
-doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-enabler = ["pytest-enabler (>=2.2)"]
-test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-itertools", "pytest (>=6,!=8.1.*)", "pytest-ignore-flaky"]
-type = ["pytest-mypy"]
-
-[[package]]
-name = "zipp"
 version = "3.21.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 optional = false
@@ -2487,5 +2270,5 @@ niswitch = ["niswitch"]
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.8"
-content-hash = "b64d94506c854c3ff6d3e55a6352fe64a8c67685374e9d20a1a399dd43e4b2e5"
+python-versions = "^3.9"
+content-hash = "8acc19b0e4cfa7483fc5cb2c6901b0b157031c469b19730ddd4b355ed655ffdb"

--- a/packages/service/pyproject.toml
+++ b/packages/service/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 # This package includes gRPC stubs that were generated with the version of grpcio-tools specified
 # below. Please keep the minimum grpcio version in sync with the grpcio-tools version. Otherwise,
 # the generated gRPC stubs may not work with the minimum grpcio version.
@@ -34,8 +34,7 @@ grpcio = "^1.49.1"
 protobuf = "^4.21"
 pywin32 = {version = ">=303", platform = "win32"}
 deprecation = ">=2.1"
-# https://github.com/microsoft/tracelogging/issues/58 - traceloggingdynamic raises TypeError with Python 3.8
-traceloggingdynamic = {version = ">=1.0", platform = "win32", python = "^3.9"}
+traceloggingdynamic = {version = ">=1.0", platform = "win32"}
 python-decouple = ">=3.8"
 nidaqmx = {version = ">=0.8.0", extras = ["grpc"], optional = true}
 nidcpower = {version = ">=1.4.4", extras = ["grpc"], optional = true}
@@ -61,7 +60,7 @@ ni-python-styleguide = ">=0.4.1"
 # When you update the grpcio-tools version, you should update the minimum grpcio version
 # and regenerate gRPC stubs.
 grpcio-tools = [
-  {version = "1.49.1", python = ">=3.8,<3.12"},
+  {version = "1.49.1", python = ">=3.9,<3.12"},
   {version = "1.59.0", python = "^3.12"},
 ]
 pytest-cov = ">=3.0.0"
@@ -78,7 +77,7 @@ types-psutil = ">=6.0"
 # NumPy dropped support for Python 3.8 before adding support for Python 3.12, so
 # we need to include multiple NumPy versions in poetry.lock.
 numpy = [
-  {version = ">=1.22", python = ">=3.8,<3.12"},
+  {version = ">=1.22", python = ">=3.9,<3.12"},
   {version = ">=1.26", python = ">=3.12,<3.13"},
 ]
 bandit = { version = ">=1.7", extras = ["toml"] }

--- a/packages/service/tox.ini
+++ b/packages/service/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 isolated_build = true
-envlist = clean, py{38,39,310,311,312}-all-extras
+envlist = clean, py{39,310,311,312}-all-extras
 
 [testenv]
 skip_install = true


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-plugin-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Remove support for Python 3.8.

### Why should this Pull Request be merged?

NI's Python support policy says:

> NI products that support or integrate with Python will drop official support for all Python versions that have reached their end of life [EOL](https://devguide.python.org/devcycle/#end-of-life-branches) . This should be done at the next release of the product following the EOL date for a given Python version

Also, more of measurement-plugin-python's dependencies (e.g. `protobuf`) have started to drop Python 3.8 support.

### What testing has been done?

PR build.