### PR TITLE
Loosen protobuf version constraint and add protobuf v4/5/6 to the test matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ InstrumentStudio and automated testing in TestStand.
 
 ## Dependencies
 
-- Python >= 3.8 [(3.9 recommended)](https://www.python.org/downloads/release/python-3913/)
+- [Python >= 3.9](https://www.python.org/downloads/release/python-3913/)
 - [grpcio >= 1.49.1, < 2.x](https://pypi.org/project/grpcio/1.49.1/)
-- [protobuf >= 4.21, < 5.x](https://pypi.org/project/protobuf/4.21.0/)
+- [protobuf >= 4.21](https://pypi.org/project/protobuf/4.21.0/)
 - [pywin32 >= 303 (Only for Windows)](https://pypi.org/project/pywin32/303/)
 
 ---

--- a/examples/game_of_life/pyproject.toml
+++ b/examples/game_of_life/pyproject.toml
@@ -14,7 +14,7 @@ click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pal
 ni-python-styleguide = ">=0.4.1"
 mypy = ">=1.0"
 grpc-stubs = "^1.53"
-types-protobuf = "^4.21"
+types-protobuf = ">=4.21"
 # Uncomment to use prerelease dependencies.
 # ni-measurement-plugin-sdk-service = {path = "../../packages/service", develop = true}
 

--- a/examples/sample_measurement/pyproject.toml
+++ b/examples/sample_measurement/pyproject.toml
@@ -16,7 +16,7 @@ mypy = ">=1.0"
 grpc-stubs = "^1.53"
 grpcio-tools = "1.49.1"
 mypy-protobuf = "^3.6.0"
-types-protobuf = "^4.21"
+types-protobuf = ">=4.21"
 # Uncomment to use prerelease dependencies.
 ni-measurement-plugin-sdk-service = {path = "../../packages/service", develop = true}
 

--- a/packages/generator/poetry.lock
+++ b/packages/generator/poetry.lock
@@ -811,7 +811,7 @@ develop = true
 [package.dependencies]
 deprecation = ">=2.1"
 grpcio = "^1.49.1"
-protobuf = "^4.21"
+protobuf = ">=4.21"
 python-decouple = ">=3.8"
 pywin32 = {version = ">=303", markers = "sys_platform == \"win32\""}
 traceloggingdynamic = {version = ">=1.0", markers = "sys_platform == \"win32\""}
@@ -1350,13 +1350,13 @@ files = [
 
 [[package]]
 name = "types-protobuf"
-version = "4.25.0.20240417"
+version = "5.29.1.20250208"
 description = "Typing stubs for protobuf"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 files = [
-    {file = "types-protobuf-4.25.0.20240417.tar.gz", hash = "sha256:c34eff17b9b3a0adb6830622f0f302484e4c089f533a46e3f147568313544352"},
-    {file = "types_protobuf-4.25.0.20240417-py3-none-any.whl", hash = "sha256:e9b613227c2127e3d4881d75d93c93b4d6fd97b5f6a099a0b654a05351c8685d"},
+    {file = "types_protobuf-5.29.1.20250208-py3-none-any.whl", hash = "sha256:c5f8bfb4afdc1b5cbca1848f2c8b361a2090add7401f410b22b599ef647bf483"},
+    {file = "types_protobuf-5.29.1.20250208.tar.gz", hash = "sha256:c1acd6a59ab554dbe09b5d1fa7dd701e2fcfb2212937a3af1c03b736060b792a"},
 ]
 
 [[package]]
@@ -1393,4 +1393,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "12968f137c7ba8fea4a180a71eedd0c9dfc9c0f508fa5f6b45b842b3711d748a"
+content-hash = "d8d8df939446d2aa8770251bfa7ab2c325ea0ff7a57cdb22490e18ef9f28847e"

--- a/packages/generator/pyproject.toml
+++ b/packages/generator/pyproject.toml
@@ -23,7 +23,7 @@ python = "^3.9"
 Mako = "^1.2.1"
 click = ">=8.1.3"
 grpcio = "^1.49.1"
-protobuf = "^4.21"
+protobuf = ">=4.21"
 black = ">=24.8.0"
 click-option-group = ">=0.5.6"
 ni-measurement-plugin-sdk-service = {version = "^2.2.0"}
@@ -34,7 +34,7 @@ pytest-cov = ">=3.0.0"
 ni-python-styleguide = ">=0.4.1"
 mypy = ">=1.0"
 mypy-protobuf = ">=3.4"
-types-protobuf = "^4.21"
+types-protobuf = ">=4.21"
 grpc-stubs = "^1.53"
 # During development, use file paths to reference the latest source for packages
 # in the same Git repository.

--- a/packages/generator/tox.ini
+++ b/packages/generator/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 isolated_build = true
-envlist = clean, py{39,310,311,312}
+envlist = clean, py{39,310,311,312}, py39-{pb4,pb5,pb6}
 
 [testenv]
 skip_install = true
@@ -14,6 +14,9 @@ passenv = RUNNER_NAME
 commands =
    poetry run python --version
    poetry install -v
+   pb4: poetry run pip install protobuf==4.25.6
+   pb5: poetry run pip install protobuf==5.29.3
+   pb6: poetry run pip install protobuf==6.30.0
    poetry run pytest -v --cov=ni_measurement_plugin_sdk_generator --cov-append --cov-report= --junitxml=test_results/nimg-{env:RUNNER_NAME}-{envname}.xml
 
 [testenv:clean]

--- a/packages/sdk/poetry.lock
+++ b/packages/sdk/poetry.lock
@@ -287,7 +287,7 @@ click-option-group = ">=0.5.6"
 grpcio = "^1.49.1"
 Mako = "^1.2.1"
 ni-measurement-plugin-sdk-service = "^2.2.0"
-protobuf = "^4.21"
+protobuf = ">=4.21"
 
 [package.source]
 type = "directory"
@@ -305,7 +305,7 @@ develop = true
 [package.dependencies]
 deprecation = ">=2.1"
 grpcio = "^1.49.1"
-protobuf = "^4.21"
+protobuf = ">=4.21"
 python-decouple = ">=3.8"
 pywin32 = {version = ">=303", markers = "sys_platform == \"win32\""}
 traceloggingdynamic = {version = ">=1.0", markers = "sys_platform == \"win32\""}

--- a/packages/service/poetry.lock
+++ b/packages/service/poetry.lock
@@ -2125,13 +2125,13 @@ files = [
 
 [[package]]
 name = "types-protobuf"
-version = "4.25.0.20240417"
+version = "5.29.1.20250208"
 description = "Typing stubs for protobuf"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 files = [
-    {file = "types-protobuf-4.25.0.20240417.tar.gz", hash = "sha256:c34eff17b9b3a0adb6830622f0f302484e4c089f533a46e3f147568313544352"},
-    {file = "types_protobuf-4.25.0.20240417-py3-none-any.whl", hash = "sha256:e9b613227c2127e3d4881d75d93c93b4d6fd97b5f6a099a0b654a05351c8685d"},
+    {file = "types_protobuf-5.29.1.20250208-py3-none-any.whl", hash = "sha256:c5f8bfb4afdc1b5cbca1848f2c8b361a2090add7401f410b22b599ef647bf483"},
+    {file = "types_protobuf-5.29.1.20250208.tar.gz", hash = "sha256:c1acd6a59ab554dbe09b5d1fa7dd701e2fcfb2212937a3af1c03b736060b792a"},
 ]
 
 [[package]]
@@ -2278,4 +2278,4 @@ niswitch = ["niswitch"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "8acc19b0e4cfa7483fc5cb2c6901b0b157031c469b19730ddd4b355ed655ffdb"
+content-hash = "469ca75e64f8aa7baa5b46e3988e8c8ff753945a19c674b368f909b11f30422b"

--- a/packages/service/pyproject.toml
+++ b/packages/service/pyproject.toml
@@ -31,7 +31,7 @@ python = "^3.9"
 # below. Please keep the minimum grpcio version in sync with the grpcio-tools version. Otherwise,
 # the generated gRPC stubs may not work with the minimum grpcio version.
 grpcio = "^1.49.1"
-protobuf = "^4.21"
+protobuf = ">=4.21"
 pywin32 = {version = ">=303", platform = "win32"}
 deprecation = ">=2.1"
 traceloggingdynamic = {version = ">=1.0", platform = "win32"}
@@ -68,7 +68,7 @@ pytest-mock = ">=3.0"
 tox = ">=4.0"
 mypy = ">=1.0"
 mypy-protobuf = ">=3.4"
-types-protobuf = "^4.21"
+types-protobuf = ">=4.21"
 types-setuptools = "*"
 types-pywin32 = ">=304"
 grpc-stubs = "^1.53"

--- a/packages/service/tox.ini
+++ b/packages/service/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 isolated_build = true
-envlist = clean, py{39,310,311,312}-all-extras
+envlist = clean, py{39,310,311,312}-all-extras, py39-{pb4,pb5,pb6}
 
 [testenv]
 skip_install = true
@@ -14,6 +14,9 @@ passenv = RUNNER_NAME
 commands =
    poetry run python --version
    poetry install -v --all-extras
+   pb4: poetry run pip install protobuf==4.25.6
+   pb5: poetry run pip install protobuf==5.29.3
+   pb6: poetry run pip install protobuf==6.30.0
    poetry run pytest -v --cov=ni_measurement_plugin_sdk_service --cov-append --cov-report= --junitxml=test_results/nims-{env:RUNNER_NAME}-{envname}.xml
 
 [testenv:clean]


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-plugin-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Remove the upper bound on `protobuf` version, allowing customers to use `protobuf` v5, v6, etc. in measurement plug-ins.

Add test coverage for `protobuf` v4 vs. v5 vs. v6. 

We do our gRPC codegen with Python 3.9 and `grpcio-tools` v1.49, which forces Poetry to lock `protobuf` v4. When we add Python 3.13 support, it will use a newer `grpcio-tools` and `protobuf` v5, since the older versions don't support Python 3.13.

### Why should this Pull Request be merged?

Fixes #677 

Ensure compatibility with `protobuf` v5 and v6, which bumped the major version due to breaking changes.

### What testing has been done?

Ran `poetry run tox -e py39-pb6` on my test machine.
Using PR build to run full test matrix.