### PR TITLE
docs: Upgrade Sphinx and change copyright year to "2022-%Y"

### DIFF
--- a/packages/service/_docs_source/conf.py
+++ b/packages/service/_docs_source/conf.py
@@ -1,6 +1,5 @@
 """Sphinx Configuration File."""
 
-import datetime
 import pathlib
 
 import autoapi.extension
@@ -27,8 +26,7 @@ proj_config = toml.loads(pyproj_file.read_text())
 
 project = proj_config["tool"]["poetry"]["name"]
 company = "National Instruments"
-year = str(datetime.datetime.now().year)
-copyright = f"{year}, {company}"
+copyright = f"2022-%Y, {company}"
 
 
 # The version info for the project you're documenting, acts as replacement for

--- a/packages/service/_docs_source/conf.py
+++ b/packages/service/_docs_source/conf.py
@@ -86,6 +86,7 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 
 intersphinx_mapping = {
+    "grpc": ("https://grpc.github.io/grpc/python/", None),
     "nidaqmx": ("https://nidaqmx-python.readthedocs.io/en/stable/", None),
     "nidcpower": ("https://nidcpower.readthedocs.io/en/stable/", None),
     "nidigital": ("https://nidigital.readthedocs.io/en/stable/", None),
@@ -93,6 +94,7 @@ intersphinx_mapping = {
     "nifgen": ("https://nifgen.readthedocs.io/en/stable/", None),
     "niscope": ("https://niscope.readthedocs.io/en/stable/", None),
     "niswitch": ("https://niswitch.readthedocs.io/en/stable/", None),
+    "protobuf": ("https://googleapis.dev/python/protobuf/latest/", None),
     "python": ("https://docs.python.org/3", None),
 }
 

--- a/packages/service/poetry.lock
+++ b/packages/service/poetry.lock
@@ -1830,6 +1830,21 @@ typing-extensions = {version = ">=4.0.0,<5.0", markers = "python_version < \"3.1
 jupyter = ["ipywidgets (>=7.5.1,<9)"]
 
 [[package]]
+name = "roman-numerals-py"
+version = "3.1.0"
+description = "Manipulate well-formed Roman numerals"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "roman_numerals_py-3.1.0-py3-none-any.whl", hash = "sha256:9da2ad2fb670bcf24e81070ceb3be72f6c11c440d73bd579fbeca1e9f330954c"},
+    {file = "roman_numerals_py-3.1.0.tar.gz", hash = "sha256:be4bf804f083a4ce001b5eb7e3c0862479d10f94c936f6c4e5f250aa5ff5bd2d"},
+]
+
+[package.extras]
+lint = ["mypy (==1.15.0)", "pyright (==1.1.394)", "ruff (==0.9.7)"]
+test = ["pytest (>=8)"]
+
+[[package]]
 name = "setuptools"
 version = "80.3.1"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
@@ -1862,39 +1877,38 @@ files = [
 
 [[package]]
 name = "sphinx"
-version = "7.4.7"
+version = "8.2.3"
 description = "Python documentation generator"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.11"
 files = [
-    {file = "sphinx-7.4.7-py3-none-any.whl", hash = "sha256:c2419e2135d11f1951cd994d6eb18a1835bd8fdd8429f9ca375dc1f3281bd239"},
-    {file = "sphinx-7.4.7.tar.gz", hash = "sha256:242f92a7ea7e6c5b406fdc2615413890ba9f699114a9c09192d7dfead2ee9cfe"},
+    {file = "sphinx-8.2.3-py3-none-any.whl", hash = "sha256:4405915165f13521d875a8c29c8970800a0141c14cc5416a38feca4ea5d9b9c3"},
+    {file = "sphinx-8.2.3.tar.gz", hash = "sha256:398ad29dee7f63a75888314e9424d40f52ce5a6a87ae88e7071e80af296ec348"},
 ]
 
 [package.dependencies]
-alabaster = ">=0.7.14,<0.8.0"
+alabaster = ">=0.7.14"
 babel = ">=2.13"
 colorama = {version = ">=0.4.6", markers = "sys_platform == \"win32\""}
 docutils = ">=0.20,<0.22"
 imagesize = ">=1.3"
-importlib-metadata = {version = ">=6.0", markers = "python_version < \"3.10\""}
 Jinja2 = ">=3.1"
 packaging = ">=23.0"
 Pygments = ">=2.17"
 requests = ">=2.30.0"
+roman-numerals-py = ">=1.0.0"
 snowballstemmer = ">=2.2"
-sphinxcontrib-applehelp = "*"
-sphinxcontrib-devhelp = "*"
-sphinxcontrib-htmlhelp = ">=2.0.0"
-sphinxcontrib-jsmath = "*"
-sphinxcontrib-qthelp = "*"
+sphinxcontrib-applehelp = ">=1.0.7"
+sphinxcontrib-devhelp = ">=1.0.6"
+sphinxcontrib-htmlhelp = ">=2.0.6"
+sphinxcontrib-jsmath = ">=1.0.1"
+sphinxcontrib-qthelp = ">=1.0.6"
 sphinxcontrib-serializinghtml = ">=1.1.9"
-tomli = {version = ">=2", markers = "python_version < \"3.11\""}
 
 [package.extras]
 docs = ["sphinxcontrib-websupport"]
-lint = ["flake8 (>=6.0)", "importlib-metadata (>=6.0)", "mypy (==1.10.1)", "pytest (>=6.0)", "ruff (==0.5.2)", "sphinx-lint (>=0.9)", "tomli (>=2)", "types-docutils (==0.21.0.20240711)", "types-requests (>=2.30.0)"]
-test = ["cython (>=3.0)", "defusedxml (>=0.7.1)", "pytest (>=8.0)", "setuptools (>=70.0)", "typing_extensions (>=4.9)"]
+lint = ["betterproto (==2.0.0b6)", "mypy (==1.15.0)", "pypi-attestations (==0.0.21)", "pyright (==1.1.395)", "pytest (>=8.0)", "ruff (==0.9.9)", "sphinx-lint (>=0.9)", "types-Pillow (==10.2.0.20240822)", "types-Pygments (==2.19.0.20250219)", "types-colorama (==0.4.15.20240311)", "types-defusedxml (==0.7.0.20240218)", "types-docutils (==0.21.0.20241128)", "types-requests (==2.32.0.20241016)", "types-urllib3 (==1.26.25.14)"]
+test = ["cython (>=3.0)", "defusedxml (>=0.7.1)", "pytest (>=8.0)", "pytest-xdist[psutil] (>=3.4)", "setuptools (>=70.0)", "typing_extensions (>=4.9)"]
 
 [[package]]
 name = "sphinx-autoapi"
@@ -2329,25 +2343,6 @@ platformdirs = ">=3.9.1,<5"
 [package.extras]
 docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.2,!=7.3)", "sphinx-argparse (>=0.4)", "sphinxcontrib-towncrier (>=0.2.1a0)", "towncrier (>=23.6)"]
 test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23.1)", "pytest (>=7.4)", "pytest-env (>=0.8.2)", "pytest-freezer (>=0.4.8)", "pytest-mock (>=3.11.1)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)", "setuptools (>=68)", "time-machine (>=2.10)"]
-
-[[package]]
-name = "zipp"
-version = "3.21.0"
-description = "Backport of pathlib-compatible object wrapper for zip files"
-optional = false
-python-versions = ">=3.9"
-files = [
-    {file = "zipp-3.21.0-py3-none-any.whl", hash = "sha256:ac1bbe05fd2991f160ebce24ffbac5f6d11d83dc90891255885223d42b3cd931"},
-    {file = "zipp-3.21.0.tar.gz", hash = "sha256:2c9958f6430a2040341a52eb608ed6dd93ef4392e02ffe219417c1b28b5dd1f4"},
-]
-
-[package.extras]
-check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1)"]
-cover = ["pytest-cov"]
-doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-enabler = ["pytest-enabler (>=2.2)"]
-test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-itertools", "pytest (>=6,!=8.1.*)", "pytest-ignore-flaky"]
-type = ["pytest-mypy"]
 
 [extras]
 drivers = ["nidaqmx", "nidcpower", "nidigital", "nidmm", "nifgen", "niscope", "niswitch"]

--- a/packages/service/poetry.lock
+++ b/packages/service/poetry.lock
@@ -800,29 +800,6 @@ files = [
 ]
 
 [[package]]
-name = "importlib-metadata"
-version = "8.7.0"
-description = "Read metadata from Python packages"
-optional = false
-python-versions = ">=3.9"
-files = [
-    {file = "importlib_metadata-8.7.0-py3-none-any.whl", hash = "sha256:e5dd1551894c77868a30651cef00984d50e1002d06942a7101d34870c5f02afd"},
-    {file = "importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000"},
-]
-
-[package.dependencies]
-zipp = ">=3.20"
-
-[package.extras]
-check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1)"]
-cover = ["pytest-cov"]
-doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-enabler = ["pytest-enabler (>=2.2)"]
-perf = ["ipython"]
-test = ["flufl.flake8", "importlib_resources (>=1.3)", "jaraco.test (>=5.4)", "packaging", "pyfakefs", "pytest (>=6,!=8.1.*)", "pytest-perf (>=0.9.2)"]
-type = ["pytest-mypy"]
-
-[[package]]
 name = "iniconfig"
 version = "2.1.0"
 description = "brain-dead simple config-ini parsing"
@@ -2357,4 +2334,4 @@ niswitch = ["niswitch"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "cb4e521c7dedf9870d66a04f1e99d9ee1862671eb0cd03a6f0a6d46c4026a2a3"
+content-hash = "8bed707d872979f42d138caa5c20342780d8ca1da5a81f20c2b034b277ce6013"

--- a/packages/service/pyproject.toml
+++ b/packages/service/pyproject.toml
@@ -97,6 +97,7 @@ traceloggingdynamic = { version = ">=1.0", platform = "linux" }
 optional = true
 
 [tool.poetry.group.docs.dependencies]
+# The latest Sphinx requires a recent Python version.
 Sphinx = { version = ">=8.2", python = "^3.11" }
 sphinx-rtd-theme = ">=1.0.0"
 sphinx-autoapi = ">=1.8.4"

--- a/packages/service/pyproject.toml
+++ b/packages/service/pyproject.toml
@@ -97,10 +97,7 @@ traceloggingdynamic = { version = ">=1.0", platform = "linux" }
 optional = true
 
 [tool.poetry.group.docs.dependencies]
-Sphinx = [
-  { version = ">=7.1.2", python = ">=3.8,<3.9" },
-  { version = ">=7.2.0", python = "^3.9" },
-]
+Sphinx = { version = ">=8.2", python = "^3.11" }
 sphinx-rtd-theme = ">=1.0.0"
 sphinx-autoapi = ">=1.8.4"
 m2r2 = ">=0.3.2"

--- a/packages/service/pyproject.toml
+++ b/packages/service/pyproject.toml
@@ -14,15 +14,15 @@ readme = "README.md" # apply the repo readme to the package as well
 repository = "https://github.com/ni/measurement-plugin-python/"
 license = "MIT"
 classifiers = [
-    "Development Status :: 5 - Production/Stable",
-    "Intended Audience :: Developers",
-    "Intended Audience :: Manufacturing",
-    "Intended Audience :: Science/Research",
-    "Operating System :: Microsoft :: Windows",
-    # Poetry automatically adds classifiers for the license and the supported Python versions.
-    "Programming Language :: Python :: Implementation :: CPython",
-    "Topic :: Scientific/Engineering",
-    "Topic :: System :: Hardware",
+  "Development Status :: 5 - Production/Stable",
+  "Intended Audience :: Developers",
+  "Intended Audience :: Manufacturing",
+  "Intended Audience :: Science/Research",
+  "Operating System :: Microsoft :: Windows",
+  # Poetry automatically adds classifiers for the license and the supported Python versions.
+  "Programming Language :: Python :: Implementation :: CPython",
+  "Topic :: Scientific/Engineering",
+  "Topic :: System :: Hardware",
 ]
 
 [tool.poetry.dependencies]
@@ -32,20 +32,28 @@ python = "^3.9"
 # the generated gRPC stubs may not work with the minimum grpcio version.
 grpcio = "^1.49.1"
 protobuf = ">=4.21"
-pywin32 = {version = ">=303", platform = "win32"}
+pywin32 = { version = ">=303", platform = "win32" }
 deprecation = ">=2.1"
-traceloggingdynamic = {version = ">=1.0", platform = "win32"}
+traceloggingdynamic = { version = ">=1.0", platform = "win32" }
 python-decouple = ">=3.8"
-nidaqmx = {version = ">=0.8.0", extras = ["grpc"], optional = true}
-nidcpower = {version = ">=1.4.4", extras = ["grpc"], optional = true}
-nidigital = {version = ">=1.4.4", extras = ["grpc"], optional = true}
-nidmm = {version = ">=1.4.4", extras = ["grpc"], optional = true}
-nifgen = {version = ">=1.4.4", extras = ["grpc"], optional = true}
-niscope = {version = ">=1.4.4", extras = ["grpc"], optional = true}
-niswitch = {version = ">=1.4.4", extras = ["grpc"], optional = true}
+nidaqmx = { version = ">=0.8.0", extras = ["grpc"], optional = true }
+nidcpower = { version = ">=1.4.4", extras = ["grpc"], optional = true }
+nidigital = { version = ">=1.4.4", extras = ["grpc"], optional = true }
+nidmm = { version = ">=1.4.4", extras = ["grpc"], optional = true }
+nifgen = { version = ">=1.4.4", extras = ["grpc"], optional = true }
+niscope = { version = ">=1.4.4", extras = ["grpc"], optional = true }
+niswitch = { version = ">=1.4.4", extras = ["grpc"], optional = true }
 
 [tool.poetry.extras]
-drivers = ["nidaqmx", "nidcpower", "nidigital", "nidmm", "nifgen", "niscope", "niswitch"]
+drivers = [
+  "nidaqmx",
+  "nidcpower",
+  "nidigital",
+  "nidmm",
+  "nifgen",
+  "niscope",
+  "niswitch",
+]
 nidaqmx = ["nidaqmx"]
 nidcpower = ["nidcpower"]
 nidigital = ["nidigital"]
@@ -60,9 +68,9 @@ ni-python-styleguide = ">=0.4.1"
 # When you update the grpcio-tools version, you should update the minimum grpcio version
 # and regenerate gRPC stubs.
 grpcio-tools = [
-  {version = "1.49.1", python = ">=3.9,<3.12"},
-  {version = "1.59.0", python = ">=3.12,<3.13"},
-  {version = "1.67.0", python = "^3.13"},
+  { version = "1.49.1", python = ">=3.9,<3.12" },
+  { version = "1.59.0", python = ">=3.12,<3.13" },
+  { version = "1.67.0", python = "^3.13" },
 ]
 pytest-cov = ">=3.0.0"
 pytest-mock = ">=3.0"
@@ -78,8 +86,8 @@ types-psutil = ">=6.0"
 # NumPy dropped support for Python 3.8 before adding support for Python 3.12, so
 # we need to include multiple NumPy versions in poetry.lock.
 numpy = [
-  {version = ">=1.22", python = ">=3.9,<3.12"},
-  {version = ">=1.26", python = "^3.12"},
+  { version = ">=1.22", python = ">=3.9,<3.12" },
+  { version = ">=1.26", python = "^3.12" },
 ]
 bandit = { version = ">=1.7", extras = ["toml"] }
 # Install traceloggingdynamic on Linux for type checking.
@@ -90,8 +98,8 @@ optional = true
 
 [tool.poetry.group.docs.dependencies]
 Sphinx = [
-  {version = ">=7.1.2", python = ">=3.8,<3.9"},
-  {version = ">=7.2.0", python = "^3.9"},
+  { version = ">=7.1.2", python = ">=3.8,<3.9" },
+  { version = ">=7.2.0", python = "^3.9" },
 ]
 sphinx-rtd-theme = ">=1.0.0"
 sphinx-autoapi = ">=1.8.4"
@@ -150,7 +158,10 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 # mypy-protobuf codegen has some unused ignores.
-module = ["ni_measurement_plugin_sdk_service._internal.stubs.*","tests.utilities.stubs.*"]
+module = [
+  "ni_measurement_plugin_sdk_service._internal.stubs.*",
+  "tests.utilities.stubs.*",
+]
 warn_unused_ignores = false
 
 [[tool.mypy.overrides]]


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-plugin-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Upgrade to the latest Sphinx, which requires Python 3.11 or later.

Change copyright year to "2022-2025" to reflect the first year when this package and its documentation were published.

Use `%Y` placeholder to specify the year. 

> [!NOTE]
> The package name was `ni-measurement-service` in 2022, then it was renamed to `ni-measurementlink-service` in 2023, and renamed again to `ni-measurement-plugin-sdk-service` in 2024.

Reformat `pyproject.toml` because I have my editor configured to reformat now.

### Why should this Pull Request be merged?

While setting up Sphinx for another project, I noticed that the Python 3.9 version constraint requires using a Sphinx version from 2023 and the `%Y` placeholder was not supported with that older version.

### What testing has been done?

Ran `poetry run sphinx-build _docs_source docs -b html -W --keep-going` and inspected the output locally.
It printed some warnings about ReadTheDocs's SSL certificates, so I'll check whether the PR build has the same warnings.
```
WARNING: failed to reach any of the inventories with the following issues:
intersphinx inventory 'https://nidcpower.readthedocs.io/en/stable/objects.inv' not fetchable due to <class 'requests.exceptions.SSLError'>: HTTPSConnectionPool(host='nidcpower.readthedocs.io', port=443): Max retries exceeded with url: /en/stable/objects.inv (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1006)')))
``` 