### PR TITLE
service: Enable type checking for tracelogging

### DIFF
--- a/packages/service/ni_measurement_plugin_sdk_service/_tracelogging.py
+++ b/packages/service/ni_measurement_plugin_sdk_service/_tracelogging.py
@@ -3,17 +3,21 @@ from __future__ import annotations
 import ctypes
 import sys
 import uuid
+from typing import TYPE_CHECKING
 
-try:
-    import traceloggingdynamic
+if sys.platform == "win32":
+    try:
+        import traceloggingdynamic
 
-    if sys.platform == "win32":
         _event_provider: traceloggingdynamic.Provider | None = traceloggingdynamic.Provider(
             b"NI-Measurement-Plug-In-Python"
         )
-    else:
+    except ImportError:
         _event_provider = None
-except ImportError:
+else:
+    if TYPE_CHECKING:
+        import traceloggingdynamic
+
     _event_provider = None
 
 _LEVEL_LOG_ALWAYS = 0

--- a/packages/service/ni_measurement_plugin_sdk_service/_tracelogging.py
+++ b/packages/service/ni_measurement_plugin_sdk_service/_tracelogging.py
@@ -7,7 +7,9 @@ import uuid
 try:
     import traceloggingdynamic
 
-    _event_provider = traceloggingdynamic.Provider(b"NI-Measurement-Plug-In-Python")
+    _event_provider: traceloggingdynamic.Provider | None = traceloggingdynamic.Provider(
+        b"NI-Measurement-Plug-In-Python"
+    )
 except ImportError:
     _event_provider = None
 
@@ -72,7 +74,7 @@ else:
 
 def is_enabled() -> bool:
     """Queries whether the event provider is enabled."""
-    return _event_provider and _event_provider.is_enabled()
+    return _event_provider is not None and _event_provider.is_enabled()
 
 
 def log_grpc_client_call_start(method_name: str) -> uuid.UUID | None:

--- a/packages/service/ni_measurement_plugin_sdk_service/_tracelogging.py
+++ b/packages/service/ni_measurement_plugin_sdk_service/_tracelogging.py
@@ -7,9 +7,12 @@ import uuid
 try:
     import traceloggingdynamic
 
-    _event_provider: traceloggingdynamic.Provider | None = traceloggingdynamic.Provider(
-        b"NI-Measurement-Plug-In-Python"
-    )
+    if sys.platform == "win32":
+        _event_provider: traceloggingdynamic.Provider | None = traceloggingdynamic.Provider(
+            b"NI-Measurement-Plug-In-Python"
+        )
+    else:
+        _event_provider = None
 except ImportError:
     _event_provider = None
 

--- a/packages/service/ni_measurement_plugin_sdk_service/_tracelogging.py
+++ b/packages/service/ni_measurement_plugin_sdk_service/_tracelogging.py
@@ -4,13 +4,16 @@ import ctypes
 import sys
 import uuid
 
-try:
-    import traceloggingdynamic
+if sys.platform == "win32":
+    try:
+        import traceloggingdynamic
 
-    _event_provider: traceloggingdynamic.Provider | None = traceloggingdynamic.Provider(
-        b"NI-Measurement-Plug-In-Python"
-    )
-except ImportError:
+        _event_provider: traceloggingdynamic.Provider | None = traceloggingdynamic.Provider(
+            b"NI-Measurement-Plug-In-Python"
+        )
+    except ImportError:
+        _event_provider = None
+else:
     _event_provider = None
 
 _LEVEL_LOG_ALWAYS = 0

--- a/packages/service/ni_measurement_plugin_sdk_service/_tracelogging.py
+++ b/packages/service/ni_measurement_plugin_sdk_service/_tracelogging.py
@@ -4,16 +4,13 @@ import ctypes
 import sys
 import uuid
 
-if sys.platform == "win32":
-    try:
-        import traceloggingdynamic
+try:
+    import traceloggingdynamic
 
-        _event_provider: traceloggingdynamic.Provider | None = traceloggingdynamic.Provider(
-            b"NI-Measurement-Plug-In-Python"
-        )
-    except ImportError:
-        _event_provider = None
-else:
+    _event_provider: traceloggingdynamic.Provider | None = traceloggingdynamic.Provider(
+        b"NI-Measurement-Plug-In-Python"
+    )
+except ImportError:
     _event_provider = None
 
 _LEVEL_LOG_ALWAYS = 0

--- a/packages/service/poetry.lock
+++ b/packages/service/poetry.lock
@@ -2184,12 +2184,13 @@ test = ["devpi-process (>=1.0.2)", "pytest (>=8.3.4)", "pytest-mock (>=3.14)"]
 
 [[package]]
 name = "traceloggingdynamic"
-version = "1.0.0"
+version = "1.0.1"
 description = "Generates Event Tracing for Windows events using TraceLogging"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "traceloggingdynamic-1.0.0.tar.gz", hash = "sha256:09b6129438b99432733de18519017a7eed8285aeaa08c0cff6de45ac60e04b75"},
+    {file = "traceloggingdynamic-1.0.1-py3-none-any.whl", hash = "sha256:0e19da491a8960725b3622366487ae35f49d8f595bb2e4e5ce1795eb5928db7c"},
+    {file = "traceloggingdynamic-1.0.1.tar.gz", hash = "sha256:d9dd4b291dd04c15e34181eed06f73fdf4ffa7b1f895b78217163def48ab1a52"},
 ]
 
 [[package]]

--- a/packages/service/poetry.lock
+++ b/packages/service/poetry.lock
@@ -2362,4 +2362,4 @@ niswitch = ["niswitch"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "1d06f08d41235fbcfe4790c57fde4b1a2b1cbe7dd5ee4faf40c046a373eaea4d"
+content-hash = "cb4e521c7dedf9870d66a04f1e99d9ee1862671eb0cd03a6f0a6d46c4026a2a3"

--- a/packages/service/pyproject.toml
+++ b/packages/service/pyproject.toml
@@ -134,8 +134,6 @@ module = [
   "grpc.framework.foundation.*",
   # https://github.com/ni/hightime/issues/4 - Add type annotations
   "hightime.*",
-  # https://github.com/microsoft/tracelogging/issues/57 - Python traceloggingdynamic package is missing py.typed marker file
-  "traceloggingdynamic",
   # https://github.com/ni/nidaqmx-python/issues/209 - Support type annotations
   "nidaqmx",
   # https://github.com/ni/nimi-python/issues/1887 - Support type annotations

--- a/packages/service/pyproject.toml
+++ b/packages/service/pyproject.toml
@@ -82,6 +82,8 @@ numpy = [
   {version = ">=1.26", python = "^3.12"},
 ]
 bandit = { version = ">=1.7", extras = ["toml"] }
+# Install traceloggingdynamic on Linux for type checking.
+traceloggingdynamic = { version = ">=1.0", platform = "linux" }
 
 [tool.poetry.group.docs]
 optional = true


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-plugin-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Update the `traceloggingdynamic` package in `poetry.lock`.

Remove `ignore_missing_imports` for `traceloggingdynamic`.

Fix a couple of typing errors in the `_tracelogging` submodule.

### Why should this Pull Request be merged?

I contributed a change to add a `py.typed` marker file to the `traceloggingdynamic` package and it has been published to PyPI: https://github.com/microsoft/tracelogging/pull/74

### What testing has been done?

Ran `poetry run nps lint` and `poetry run mypy`