### PR TITLE
docs: Remove Sphinx --keep-going option

### DIFF
--- a/.github/workflows/check_nims.yml
+++ b/.github/workflows/check_nims.yml
@@ -76,7 +76,7 @@ jobs:
         run: |
           rm -rf docs
           mkdir -p docs   
-          poetry run sphinx-build _docs_source docs -b html -W --keep-going
+          poetry run sphinx-build _docs_source docs -b html -W
       - name: Revert docs
         run:  rm -rf docs
       - name: Generate gRPC stubs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,7 +166,7 @@ The `ni_measurement_plugin_sdk_service` package uses Sphinx to build API
 reference documentation.
 
 ```cmd
-poetry run sphinx-build _docs_source docs -b html -W --keep-going
+poetry run sphinx-build _docs_source docs -b html -W
 ```
 
 The generated documentation is at `docs/index.html`.


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-plugin-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Remove `--keep-going` from the Sphinx command line

### Why should this Pull Request be merged?

`--keep-going` is always enabled in Sphinx 8.1+: https://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-keep-going

### What testing has been done?

PR build