### PR TITLE
renovate: Pin GitHub Action digests

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,7 +5,8 @@
     "config:recommended", 
     ":maintainLockFilesWeekly",
     ":automergePatch",
-    "schedule:automergeDaily"
+    "schedule:automergeDaily",
+    "helpers:pinGitHubActionDigestsToSemver"
   ],
   "git-submodules": {
     "automerge": true,


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-plugin-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Enable [helpers:pinGitHubActionDigestsToSemver](https://docs.renovatebot.com/presets-helpers/#helperspingithubactiondigeststosemver), which causes Renovate to do two things:
- Replace `actions/whatever@v3` with `actions/whatever@<sha-hash> # v3`
- Replace `actions/whatever@<sha-hash> # v3` with `actions/whatever@<sha-hash> # v3.1.7`

### Why should this Pull Request be merged?

Pinning GitHub action digests improves build reproducibility and is a security best practice.

### What testing has been done?

Tested in https://github.com/ni/nitypes-python/blob/main/.github/renovate.json