### PR TITLE
github: Fix github-actions package rules

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -19,7 +19,7 @@
     },
     {
       // Update GitHub Actions on weekends.
-      "matchCategories": ["github-actions"],
+      "matchManagers": ["github-actions"],
       "groupName": "GitHub Actions",
       "groupSlug": "github",
       "schedule": [


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-plugin-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Update Renovate config to use `matchManagers` not `matchCategories` for `github-actions`.

### Why should this Pull Request be merged?

The manager name is `github-actions` and the category is `ci`.

### What testing has been done?

None