### PR TITLE
feat: Add support for Measurement Remote Execution by populating deployment_target

### DIFF
--- a/packages/service/ni_measurement_plugin_sdk_service/_drivers/_grpcdevice.py
+++ b/packages/service/ni_measurement_plugin_sdk_service/_drivers/_grpcdevice.py
@@ -36,8 +36,13 @@ def get_grpc_device_server_location(
         )
         return service_location
 
+    compute_nodes = discovery_client.enumerate_compute_nodes()
+    remote_nodes = [node for node in compute_nodes if not node.is_local]
+    first_remote_node_url = remote_nodes[0].url if len(remote_nodes) == 1 else ""
+    
     service_location = discovery_client.resolve_service(
         provided_interface=provided_interface,
+        deployment_target=first_remote_node_url,
         service_class=SERVICE_CLASS,
     )
     _logger.debug(

--- a/packages/service/ni_measurement_plugin_sdk_service/discovery/_client.py
+++ b/packages/service/ni_measurement_plugin_sdk_service/discovery/_client.py
@@ -24,6 +24,7 @@ from ni_measurement_plugin_sdk_service.grpc.channelpool import GrpcChannelPool
 from ni_measurement_plugin_sdk_service.measurement.info import (
     MeasurementInfo,
     ServiceInfo,
+    ComputeNodeDescriptor,
 )
 
 _logger = logging.getLogger(__name__)
@@ -304,3 +305,15 @@ class DiscoveryClient:
         response = self._get_stub().EnumerateServices(request)
 
         return [ServiceInfo._from_grpc(service) for service in response.available_services]
+
+    def enumerate_compute_nodes(self) -> Sequence[ComputeNodeDescriptor]:
+        """Enumerates all compute nodes registered with the discovery service.
+
+        Returns:
+            The list of information describing the compute nodes.
+        """
+        request = discovery_service_pb2.EnumerateComputeNodesRequest()
+
+        response = self._get_stub().EnumerateComputeNodes(request)
+
+        return [ComputeNodeDescriptor._from_grpc(node) for node in response.compute_nodes]

--- a/packages/service/ni_measurement_plugin_sdk_service/measurement/info.py
+++ b/packages/service/ni_measurement_plugin_sdk_service/measurement/info.py
@@ -80,6 +80,23 @@ class ServiceInfo(NamedTuple):
             versions=list(other.versions),
         )
 
+class ComputeNodeDescriptor(NamedTuple):
+    """A named tuple providing information about a compute node.
+
+    This class is used with the NI Discovery Service when enumerating compute nodes.
+    """
+    url: str
+    """The resolvable name (URL) of the compute node."""
+
+    is_local: bool
+    """Indicates whether the compute node is local node."""
+
+    @classmethod
+    def _from_grpc(cls, grpc_obj: discovery_service_pb2.ComputeNodeDescriptor) -> ComputeNodeDescriptor:
+        return ComputeNodeDescriptor(
+            url=grpc_obj.url,
+            is_local=grpc_obj.is_local,
+        )
 
 class TypeSpecialization(enum.Enum):
     """Enum that represents the type specializations for measurement parameters."""

--- a/packages/service/ni_measurement_plugin_sdk_service/pin_map/_client.py
+++ b/packages/service/ni_measurement_plugin_sdk_service/pin_map/_client.py
@@ -60,8 +60,14 @@ class PinMapClient:
                         grpc_channel_pool=self._grpc_channel_pool
                     )
                 if self._stub is None:
+                    
+                    compute_nodes = self._discovery_client.enumerate_compute_nodes()
+                    remote_nodes = [node for node in compute_nodes if not node.is_local]
+                    first_remote_node_url = remote_nodes[0].url if len(remote_nodes) == 1 else ""
+
                     service_location = self._discovery_client.resolve_service(
                         provided_interface=GRPC_SERVICE_INTERFACE_NAME,
+                        deployment_target=first_remote_node_url,
                         service_class=GRPC_SERVICE_CLASS,
                     )
                     channel = self._grpc_channel_pool.get_channel(service_location.insecure_address)

--- a/packages/service/ni_measurement_plugin_sdk_service/session_management/_client.py
+++ b/packages/service/ni_measurement_plugin_sdk_service/session_management/_client.py
@@ -75,8 +75,14 @@ class SessionManagementClient:
                         grpc_channel_pool=self._grpc_channel_pool
                     )
                 if self._stub is None:
+                    
+                    compute_nodes = self._discovery_client.enumerate_compute_nodes()
+                    remote_nodes = [node for node in compute_nodes if not node.is_local]
+                    first_remote_node_url = remote_nodes[0].url if len(remote_nodes) == 1 else ""
+                    
                     service_location = self._discovery_client.resolve_service(
                         provided_interface=GRPC_SERVICE_INTERFACE_NAME,
+                        deployment_target=first_remote_node_url,
                         service_class=GRPC_SERVICE_CLASS,
                     )
                     channel = self._grpc_channel_pool.get_channel(service_location.insecure_address)


### PR DESCRIPTION
<!-- TODO: Check the below box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/measurement-plugin-python/blob/main/CONTRIBUTING.md) -->
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-plugin-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

This Pull Request implements support for the [Feature 3069888](https://dev.azure.com/ni/DevCentral/_workitems/edit/3069888): Execute measurement plug-ins using remote instruments with Session Management​.
It enables accessing instrument resources hosted on a remote test bench machine from developer machines. To achieve this, the `EnumerateComputeNodes` API that returns the remote test bench URL as a compute node is implemented in the `DiscoveryClient` and integrated into the service clients:

* gRPC Device Server Activation service
* Session Management service
* Pin map service

These clients use the `EnumerateComputeNodes` API to detect remote compute nodes and populate the `deployment_target` accordingly. As a result, all service requests are resolved and sent to the appropriate remote services instead of the local host. If no remote compute nodes are found, the system falls back to the current local behavior.

### Why should this Pull Request be merged?

This change is essential for enabling seamless execution of measurement plug-ins using remote instrument resources. By allowing service clients to resolve and communicate with remote services transparently, developers can work remotely without changing existing workflows.

### What testing has been done?

TODO: Add automation tests.

### Additional references:
* [Pull Request 948366](https://dev.azure.com/ni/DevCentral/_git/ASW/pullrequest/948366): HLD to execute measurement plug-ins using remote instruments with Session Management​
* [Pull Request 1004993](https://dev.azure.com/ni/DevCentral/_git/ASW/pullrequest/1004993): Service clients: Populate the respective clients with the deployment target