### PR TITLE
fix(deps): Enable testing with latest click

### DIFF
--- a/packages/generator/poetry.lock
+++ b/packages/generator/poetry.lock
@@ -108,6 +108,20 @@ files = [
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
+name = "click"
+version = "8.2.1"
+description = "Composable command line interface toolkit"
+optional = false
+python-versions = ">=3.10"
+files = [
+    {file = "click-8.2.1-py3-none-any.whl", hash = "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b"},
+    {file = "click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[[package]]
 name = "click-option-group"
 version = "0.5.7"
 description = "Option groups missing in Click"
@@ -1486,4 +1500,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "edf34e9604793e0b2dfe311887579f3a414beb4ceff9525b61385b040bf487bc"
+content-hash = "2b6d44e6366cf51632fac5f5bc3756bb9430c3936aef62ea68dbb74e0b195ed5"

--- a/packages/generator/pyproject.toml
+++ b/packages/generator/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
 python = "^3.9"
 Mako = "^1.2.1"
 click = [
+  # When dropping support for Python 3.9, remove the version check from tests/conftest.py
   {version = ">=8.1.3,<8.2.0", python = ">=3.9,<3.10"},
   {version = ">=8.1.3", python = "^3.10"},
 ]  

--- a/packages/generator/pyproject.toml
+++ b/packages/generator/pyproject.toml
@@ -21,7 +21,10 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.9"
 Mako = "^1.2.1"
-click = ">=8.1.3"
+click = [
+  {version = ">=8.1.3,<8.2.0", python = ">=3.9,<3.10"},
+  {version = ">=8.1.3", python = "^3.10"},
+]  
 grpcio = "^1.49.1"
 protobuf = ">=4.21"
 black = ">=24.8.0"


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-plugin-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

generator:
- Specify click versions separately for Python 3.9 vs. Python 3.10+
- Update tests to support click 8.2. The CliRunner constructor's `mix_stderr` parameter has been removed. Instead, there is a separate `output` property containing the mixed stream.

I am not updating the examples. They will continue to use the old click until we drop Python 3.9 support later this year.

### Why should this Pull Request be merged?

click no longer supports Python 3.9. Specifying multiple versions allows Poetry to lock different versions for Python 3.9 vs. Python 3.10+, which allows Renovate to keep this package up to date for testing and development.

### What testing has been done?

PR build