### PR TITLE
tests: Fix race condition in client cancellation tests

### DIFF
--- a/packages/generator/tests/acceptance/test_streaming_measurement_client.py
+++ b/packages/generator/tests/acceptance/test_streaming_measurement_client.py
@@ -73,13 +73,17 @@ def test___non_streaming_measurement_execution___cancel___cancels_measurement(
 ) -> None:
     test_measurement_client_type = getattr(measurement_plugin_client_module, "TestMeasurement")
     measurement_plugin_client = test_measurement_client_type()
+    streaming_data_measurement.measurement_started_event.clear()
+    is_canceled = False
 
     with pytest.raises(grpc.RpcError) as exc_info:
         with concurrent.futures.ThreadPoolExecutor() as executor:
             measure = executor.submit(measurement_plugin_client.measure)
-            measurement_plugin_client.cancel()
+            streaming_data_measurement.measurement_started_event.wait()
+            is_canceled = measurement_plugin_client.cancel()
             measure.result()
 
+    assert is_canceled
     assert exc_info.value.code() == grpc.StatusCode.CANCELLED
 
 
@@ -88,13 +92,17 @@ def test___streaming_measurement_execution___cancel___cancels_measurement(
 ) -> None:
     test_measurement_client_type = getattr(measurement_plugin_client_module, "TestMeasurement")
     measurement_plugin_client = test_measurement_client_type()
+    streaming_data_measurement.measurement_started_event.clear()
+    is_canceled = False
 
     with pytest.raises(grpc.RpcError) as exc_info:
         with concurrent.futures.ThreadPoolExecutor() as executor:
             measure = executor.submit(lambda: list(measurement_plugin_client.stream_measure()))
-            measurement_plugin_client.cancel()
+            streaming_data_measurement.measurement_started_event.wait()
+            is_canceled = measurement_plugin_client.cancel()
             measure.result()
 
+    assert is_canceled
     assert exc_info.value.code() == grpc.StatusCode.CANCELLED
 
 

--- a/packages/generator/tests/utilities/measurements/streaming_data_measurement/__init__.py
+++ b/packages/generator/tests/utilities/measurements/streaming_data_measurement/__init__.py
@@ -21,6 +21,8 @@ measurement_service = nims.MeasurementService(
 
 Outputs = tuple[str, int, list[int]]
 
+measurement_started_event = threading.Event()
+
 
 @measurement_service.register_measurement
 @measurement_service.configuration("name", nims.DataType.String, "<Name>")
@@ -41,6 +43,8 @@ def measure(
     error_on_index: int,
 ) -> Generator[Outputs]:
     """Returns the number of responses requested at the requested interval."""
+    measurement_started_event.set()
+
     cancellation_event = threading.Event()
     measurement_service.context.add_cancel_callback(cancellation_event.set)
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-plugin-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Add a "measurement started" event object to `packages\generator\tests\utilities\measurements\streaming_data_measurement\__init__.py` and update `packages\generator\tests\acceptance\test_streaming_measurement_client.py` to wait for the event before cancelling.

I previously suggested this in https://github.com/ni/measurement-plugin-python/pull/870#discussion_r1752939058 . It looks like @Jotheeswaran-Nandagopal thought I was talking about a different event and I overlooked the fact that the comment thread had been closed without implementing the suggestion.

### Why should this Pull Request be merged?

Fixes #1172 and [AB#3162086](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3162086)

### What testing has been done?

Ran `poetry run pytest -v --count 100000 -x -k test___non_streaming_measurement_execution___cancel___cancels_measurement .\tests\acceptance\test_streaming_measurement_client.py --log-level debug` with pytest-repeat installed