### PR TITLE
service: Remove hardcoded nims references from _dotenvpath

### DIFF
--- a/packages/service/ni_measurement_plugin_sdk_service/_dotenvpath.py
+++ b/packages/service/ni_measurement_plugin_sdk_service/_dotenvpath.py
@@ -40,12 +40,12 @@ def _get_script_or_exe_path() -> Path | None:
 
 
 def _get_caller_path() -> Path | None:
-    """Get the path of the module calling into ni_measurement_plugin_sdk_service, if possible."""
-    nims_path = _get_nims_path()
+    """Get the path of the module calling into this package, if possible."""
+    package_path = _get_package_path()
     for frame, _ in traceback.walk_stack(inspect.currentframe()):
         if frame.f_code.co_filename:
             module_path = Path(frame.f_code.co_filename)
-            if _exists(module_path) and not module_path.is_relative_to(nims_path):
+            if _exists(module_path) and not module_path.is_relative_to(package_path):
                 return module_path
 
     return None
@@ -66,8 +66,8 @@ else:
         return os.path.exists(path)
 
 
-def _get_nims_path() -> Path:
-    """Get the path of the ni_measurement_plugin_sdk_service package."""
-    nims_module = sys.modules["ni_measurement_plugin_sdk_service"]
-    assert nims_module.__file__ and nims_module.__file__.endswith("__init__.py")
-    return Path(nims_module.__file__).parent
+def _get_package_path() -> Path:
+    """Get the path of this package."""
+    package = sys.modules[__package__]
+    assert package.__file__ and package.__file__.endswith("__init__.py")
+    return Path(package.__file__).parent

--- a/packages/service/tests/unit/test_dotenvpath.py
+++ b/packages/service/tests/unit/test_dotenvpath.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+
 from ni_measurement_plugin_sdk_service import _dotenvpath
 
 

--- a/packages/service/tests/unit/test_dotenvpath.py
+++ b/packages/service/tests/unit/test_dotenvpath.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 
 import pytest
-
 from ni_measurement_plugin_sdk_service import _dotenvpath
 
 
@@ -23,8 +22,8 @@ def test___get_caller_path___returns_this_modules_path() -> None:
     assert _dotenvpath._get_caller_path() == Path(__file__)
 
 
-def test___get_nims_path___returns_package_dir() -> None:
-    assert _dotenvpath._get_nims_path() == Path(_dotenvpath.__file__).parent
+def test___get_package_path___returns_package_dir() -> None:
+    assert _dotenvpath._get_package_path() == Path(_dotenvpath.__file__).parent
 
 
 def test___get_script_or_exe_path___returns_pytest_path() -> None:


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-plugin-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

`_dotenvpath`:
- Change `nims_path` to `package_path`
- Use `sys.modules[__package__]` instead of hardcoding package name

### Why should this Pull Request be merged?

Incorporate feedback from https://github.com/ni/nidaqmx-python/pull/799

### What testing has been done?

Ran unit tests