### PR TITLE
Fix tests with resource names when InstrumentStudio 2025Q3 is installed

### DIFF
--- a/packages/service/tests/acceptance/test_nidcpower_measurement.py
+++ b/packages/service/tests/acceptance/test_nidcpower_measurement.py
@@ -59,11 +59,16 @@ def test___multiple_sessions___measure___creates_multiple_sessions(
 
     outputs = _measure(stub_v2, pin_map_context, configurations)
 
-    assert _get_output(outputs) == [
+    actual = _get_output(outputs)
+    expected1 = [
         _MeasurementOutput("DCPower1/0", "DCPower1/0", "DCPower1/0", "DCPower1/0"),
         _MeasurementOutput("DCPower1/2", "DCPower1/2", "DCPower1/2", "DCPower1/2"),
     ]
-
+    expected2 = [
+        _MeasurementOutput("niDCPower-DCPower1/0", "DCPower1/0", "DCPower1/0", "DCPower1/0"),
+        _MeasurementOutput("niDCPower-DCPower1/2", "DCPower1/2", "DCPower1/2", "DCPower1/2"),
+    ]
+    assert actual == expected1 or actual == expected2
 
 def _measure(
     stub_v2: MeasurementServiceStub,

--- a/packages/service/tests/acceptance/test_nidcpower_measurement.py
+++ b/packages/service/tests/acceptance/test_nidcpower_measurement.py
@@ -70,6 +70,7 @@ def test___multiple_sessions___measure___creates_multiple_sessions(
     ]
     assert actual == expected1 or actual == expected2
 
+
 def _measure(
     stub_v2: MeasurementServiceStub,
     pin_map_context: PinMapContext,

--- a/packages/service/tests/acceptance/test_nidigital_measurement.py
+++ b/packages/service/tests/acceptance/test_nidigital_measurement.py
@@ -45,7 +45,8 @@ def test___single_session___measure___creates_single_session(
 
     outputs = _measure(stub_v2, pin_map_context, configurations)
 
-    assert _get_output(outputs) == [
+    actual = _get_output(outputs)
+    expected1 = [
         _MeasurementOutput(
             "DigitalPattern1",
             "DigitalPattern1",
@@ -53,6 +54,15 @@ def test___single_session___measure___creates_single_session(
             "site0/CS",
         )
     ]
+    expected2 = [
+        _MeasurementOutput(
+            "niDigitalPattern-DigitalPattern1",
+            "DigitalPattern1",
+            "site0/CS, site0/SCLK, site0/MOSI, site0/MISO",
+            "site0/CS",
+        )
+    ]
+    assert actual == expected1 or actual == expected2
 
 
 def test___multiple_sessions___measure___creates_multiple_sessions(
@@ -63,8 +73,9 @@ def test___multiple_sessions___measure___creates_multiple_sessions(
     configurations = Configurations(pin_names=["CS", "SCLK", "MOSI", "MISO"], multi_session=True)
 
     outputs = _measure(stub_v2, pin_map_context, configurations)
-
-    assert _get_output(outputs) == [
+    
+    actual = _get_output(outputs)
+    expected1 = [
         _MeasurementOutput(
             "DigitalPattern1",
             "DigitalPattern1",
@@ -78,6 +89,21 @@ def test___multiple_sessions___measure___creates_multiple_sessions(
             "site1/CS, site1/SCLK, site1/MOSI, site1/MISO",
         ),
     ]
+    expected2 = [
+        _MeasurementOutput(
+            "niDigitalPattern-DigitalPattern1",
+            "DigitalPattern1",
+            "site0/CS, site0/SCLK, site0/MOSI, site0/MISO",
+            "site0/CS, site0/SCLK, site0/MOSI, site0/MISO",
+        ),
+        _MeasurementOutput(
+            "niDigitalPattern-DigitalPattern2",
+            "DigitalPattern2",
+            "site1/CS, site1/SCLK, site1/MOSI, site1/MISO",
+            "site1/CS, site1/SCLK, site1/MOSI, site1/MISO",
+        ),
+    ]
+    assert actual == expected1 or actual == expected2
 
 
 def _measure(

--- a/packages/service/tests/acceptance/test_nidigital_measurement.py
+++ b/packages/service/tests/acceptance/test_nidigital_measurement.py
@@ -73,7 +73,7 @@ def test___multiple_sessions___measure___creates_multiple_sessions(
     configurations = Configurations(pin_names=["CS", "SCLK", "MOSI", "MISO"], multi_session=True)
 
     outputs = _measure(stub_v2, pin_map_context, configurations)
-    
+
     actual = _get_output(outputs)
     expected1 = [
         _MeasurementOutput(

--- a/packages/service/tests/acceptance/test_nidmm_measurement.py
+++ b/packages/service/tests/acceptance/test_nidmm_measurement.py
@@ -60,10 +60,16 @@ def test___multiple_sessions___measure___creates_multiple_sessions(
 
     outputs = _measure(stub_v2, pin_map_context, configurations)
 
-    assert _get_output(outputs) == [
+    actual = _get_output(outputs)
+    expected1 = [
         _MeasurementOutput("DMM1", "DMM1", "0", "0"),
         _MeasurementOutput("DMM2", "DMM2", "0", "0"),
     ]
+    expected2 = [
+        _MeasurementOutput("niDMM-DMM1", "DMM1", "0", "0"),
+        _MeasurementOutput("niDMM-DMM2", "DMM2", "0", "0"),
+    ]
+    assert actual == expected1 or actual == expected2
 
 
 def _measure(

--- a/packages/service/tests/acceptance/test_nifgen_measurement.py
+++ b/packages/service/tests/acceptance/test_nifgen_measurement.py
@@ -45,10 +45,16 @@ def test___multiple_sessions___measure___creates_multiple_sessions(
 
     outputs = _measure(stub_v2, pin_map_context, configurations)
 
-    assert _get_output(outputs) == [
+    actual = _get_output(outputs)
+    expected1 = [
         _MeasurementOutput("FGEN1", "FGEN1", "0", "0"),
         _MeasurementOutput("FGEN2", "FGEN2", "0", "0"),
     ]
+    expected2 = [
+        _MeasurementOutput("niFGen-FGEN1", "FGEN1", "0", "0"),
+        _MeasurementOutput("niFGen-FGEN2", "FGEN2", "0", "0"),
+    ]
+    assert actual == expected1 or actual == expected2
 
 
 def _measure(

--- a/packages/service/tests/acceptance/test_niscope_measurement.py
+++ b/packages/service/tests/acceptance/test_niscope_measurement.py
@@ -55,7 +55,7 @@ def test___multiple_sessions___measure___creates_multiple_sessions(
     configurations = Configurations(pin_names=["Pin1", "Pin2"], multi_session=True)
 
     outputs = _measure(stub_v2, pin_map_context, configurations)
-    
+
     actual = _get_output(outputs)
     expected1 = [
         _MeasurementOutput("SCOPE1", "SCOPE1", "0", "0"),

--- a/packages/service/tests/acceptance/test_niscope_measurement.py
+++ b/packages/service/tests/acceptance/test_niscope_measurement.py
@@ -55,11 +55,17 @@ def test___multiple_sessions___measure___creates_multiple_sessions(
     configurations = Configurations(pin_names=["Pin1", "Pin2"], multi_session=True)
 
     outputs = _measure(stub_v2, pin_map_context, configurations)
-
-    assert _get_output(outputs) == [
+    
+    actual = _get_output(outputs)
+    expected1 = [
         _MeasurementOutput("SCOPE1", "SCOPE1", "0", "0"),
         _MeasurementOutput("SCOPE2", "SCOPE2", "0", "0"),
     ]
+    expected2 = [
+        _MeasurementOutput("niScope-SCOPE1", "SCOPE1", "0", "0"),
+        _MeasurementOutput("niScope-SCOPE2", "SCOPE2", "0", "0"),
+    ]
+    assert actual == expected1 or actual == expected2
 
 
 def _measure(

--- a/packages/service/tests/acceptance/test_niswitch_measurement.py
+++ b/packages/service/tests/acceptance/test_niswitch_measurement.py
@@ -35,12 +35,8 @@ def test___single_session___measure___creates_single_session(
     outputs = _measure(stub_v2, pin_map_context, configurations)
 
     actual = _get_output(outputs)
-    expected1 = [
-        _MeasurementOutput("RelayDriver1", "RelayDriver1", "K0", "K0")
-    ]
-    expected2 = [
-        _MeasurementOutput("niRelayDriver-RelayDriver1", "RelayDriver1", "K0", "K0")
-    ]
+    expected1 = [_MeasurementOutput("RelayDriver1", "RelayDriver1", "K0", "K0")]
+    expected2 = [_MeasurementOutput("niRelayDriver-RelayDriver1", "RelayDriver1", "K0", "K0")]
     assert actual == expected1 or actual == expected2
 
 

--- a/packages/service/tests/acceptance/test_niswitch_measurement.py
+++ b/packages/service/tests/acceptance/test_niswitch_measurement.py
@@ -34,7 +34,14 @@ def test___single_session___measure___creates_single_session(
 
     outputs = _measure(stub_v2, pin_map_context, configurations)
 
-    assert _get_output(outputs) == [_MeasurementOutput("RelayDriver1", "RelayDriver1", "K0", "K0")]
+    actual = _get_output(outputs)
+    expected1 = [
+        _MeasurementOutput("RelayDriver1", "RelayDriver1", "K0", "K0")
+    ]
+    expected2 = [
+        _MeasurementOutput("niRelayDriver-RelayDriver1", "RelayDriver1", "K0", "K0")
+    ]
+    assert actual == expected1 or actual == expected2
 
 
 def test___multiple_sessions___measure___creates_multiple_sessions(
@@ -44,11 +51,16 @@ def test___multiple_sessions___measure___creates_multiple_sessions(
     configurations = Configurations(relay_names=["SiteRelay1", "SiteRelay2"], multi_session=True)
 
     outputs = _measure(stub_v2, pin_map_context, configurations)
-
-    assert _get_output(outputs) == [
+    actual = _get_output(outputs)
+    expected1 = [
         _MeasurementOutput("RelayDriver1", "RelayDriver1", "K0", "K0"),
         _MeasurementOutput("RelayDriver2", "RelayDriver2", "K1", "K1"),
     ]
+    expected2 = [
+        _MeasurementOutput("niRelayDriver-RelayDriver1", "RelayDriver1", "K0", "K0"),
+        _MeasurementOutput("niRelayDriver-RelayDriver2", "RelayDriver2", "K1", "K1"),
+    ]
+    assert actual == expected1 or actual == expected2
 
 
 def _measure(

--- a/packages/service/tests/acceptance/test_session_management.py
+++ b/packages/service/tests/acceptance/test_session_management.py
@@ -50,6 +50,7 @@ class Configuration(NamedTuple):
     expected_session_names: Iterable[str]
     expected_resource_names: Iterable[str]
     expected_channel_lists: Iterable[str]
+    expected_session_names2: Iterable[str]
 
 
 _FGEN_SINGLE_SESSION_CONFIGURATIONS = [
@@ -60,6 +61,7 @@ _FGEN_SINGLE_SESSION_CONFIGURATIONS = [
         ["FGEN1"],
         ["FGEN1"],
         ["0"],
+        expected_session_names2=["niFGen-FGEN1"],
     ),
     Configuration(
         "2Fgen2Pin2Site.pinmap",
@@ -68,6 +70,7 @@ _FGEN_SINGLE_SESSION_CONFIGURATIONS = [
         ["FGEN1"],
         ["FGEN1"],
         ["0"],
+        expected_session_names2=["niFGen-FGEN1"],
     ),
     Configuration(
         "2Fgen2Pin2Site.pinmap",
@@ -76,6 +79,7 @@ _FGEN_SINGLE_SESSION_CONFIGURATIONS = [
         ["FGEN1"],
         ["FGEN1"],
         ["0, 1"],
+        expected_session_names2=["niFGen-FGEN1"],
     ),
     Configuration(
         "2Fgen2Pin2Site.pinmap",
@@ -84,6 +88,7 @@ _FGEN_SINGLE_SESSION_CONFIGURATIONS = [
         ["FGEN2"],
         ["FGEN2"],
         ["0, 1"],
+        expected_session_names2=["niFGen-FGEN2"],
     ),
 ]
 
@@ -95,6 +100,7 @@ _FGEN_MULTI_SESSION_CONFIGURATIONS = [
         ["FGEN1", "FGEN2"],
         ["FGEN1", "FGEN2"],
         ["0, 1", "0, 1"],
+        expected_session_names2=["niFGen-FGEN1", "niFGen-FGEN2"],
     ),
 ]
 
@@ -106,6 +112,7 @@ _SMU_SINGLE_SESSION_CONFIGURATIONS = [
         ["DCPower1/0"],
         ["DCPower1/0"],
         ["DCPower1/0"],
+        expected_session_names2=["niDCPower-DCPower1/0"],
     ),
     Configuration(
         "1Smu1ChannelGroup2Pin2Site.pinmap",
@@ -114,6 +121,7 @@ _SMU_SINGLE_SESSION_CONFIGURATIONS = [
         ["DCPower1/0, DCPower1/1, DCPower1/2, DCPower1/3"],
         ["DCPower1/0, DCPower1/1, DCPower1/2, DCPower1/3"],
         ["DCPower1/0"],
+        expected_session_names2=["niDCPower-DCPower1/0, DCPower1/1, DCPower1/2, DCPower1/3"],
     ),
     Configuration(
         "1Smu1ChannelGroup2Pin2Site.pinmap",
@@ -122,6 +130,7 @@ _SMU_SINGLE_SESSION_CONFIGURATIONS = [
         ["DCPower1/0, DCPower1/1, DCPower1/2, DCPower1/3"],
         ["DCPower1/0, DCPower1/1, DCPower1/2, DCPower1/3"],
         ["DCPower1/0, DCPower1/1"],
+        expected_session_names2=["niDCPower-DCPower1/0, DCPower1/1, DCPower1/2, DCPower1/3"],
     ),
     Configuration(
         "1Smu1ChannelGroup2Pin2Site.pinmap",
@@ -130,6 +139,7 @@ _SMU_SINGLE_SESSION_CONFIGURATIONS = [
         ["DCPower1/0, DCPower1/1, DCPower1/2, DCPower1/3"],
         ["DCPower1/0, DCPower1/1, DCPower1/2, DCPower1/3"],
         ["DCPower1/0, DCPower1/2"],
+        expected_session_names2=["niDCPower-DCPower1/0, DCPower1/1, DCPower1/2, DCPower1/3"],
     ),
     Configuration(
         "1Smu1ChannelGroup2Pin2Site.pinmap",
@@ -138,6 +148,7 @@ _SMU_SINGLE_SESSION_CONFIGURATIONS = [
         ["DCPower1/0, DCPower1/1, DCPower1/2, DCPower1/3"],
         ["DCPower1/0, DCPower1/1, DCPower1/2, DCPower1/3"],
         ["DCPower1/0, DCPower1/1, DCPower1/2, DCPower1/3"],
+        expected_session_names2=["niDCPower-DCPower1/0, DCPower1/1, DCPower1/2, DCPower1/3"],
     ),
     Configuration(
         "1Smu2ChannelGroup2Pin2Site.pinmap",
@@ -146,6 +157,7 @@ _SMU_SINGLE_SESSION_CONFIGURATIONS = [
         ["DCPower1/0, DCPower1/1"],
         ["DCPower1/0, DCPower1/1"],
         ["DCPower1/0"],
+        expected_session_names2=["niDCPower-DCPower1/0, DCPower1/1"],
     ),
     Configuration(
         "1Smu2ChannelGroup2Pin2Site.pinmap",
@@ -154,6 +166,7 @@ _SMU_SINGLE_SESSION_CONFIGURATIONS = [
         ["DCPower1/0, DCPower1/1"],
         ["DCPower1/0, DCPower1/1"],
         ["DCPower1/0, DCPower1/1"],
+        expected_session_names2=["niDCPower-DCPower1/0, DCPower1/1"],
     ),
     Configuration(
         "1Smu2ChannelGroup2Pin2Site.pinmap",
@@ -162,6 +175,7 @@ _SMU_SINGLE_SESSION_CONFIGURATIONS = [
         ["DCPower1/2, DCPower1/3"],
         ["DCPower1/2, DCPower1/3"],
         ["DCPower1/2, DCPower1/3"],
+        expected_session_names2=["niDCPower-DCPower1/2, DCPower1/3"]
     ),
     Configuration(
         "2Smu2ChannelGroup2Pin2Site.pinmap",
@@ -170,6 +184,7 @@ _SMU_SINGLE_SESSION_CONFIGURATIONS = [
         ["DCPower1/0, DCPower1/1"],
         ["DCPower1/0, DCPower1/1"],
         ["DCPower1/0"],
+        expected_session_names2=["niDCPower-DCPower1/0, DCPower1/1"],
     ),
     Configuration(
         "2Smu2ChannelGroup2Pin2Site.pinmap",
@@ -178,6 +193,7 @@ _SMU_SINGLE_SESSION_CONFIGURATIONS = [
         ["DCPower1/0, DCPower1/1"],
         ["DCPower1/0, DCPower1/1"],
         ["DCPower1/0, DCPower1/1"],
+        expected_session_names2=["niDCPower-DCPower1/0, DCPower1/1"],
     ),
     Configuration(
         "2Smu2ChannelGroup2Pin2Site.pinmap",
@@ -186,6 +202,7 @@ _SMU_SINGLE_SESSION_CONFIGURATIONS = [
         ["DCPower2/0, DCPower2/1"],
         ["DCPower2/0, DCPower2/1"],
         ["DCPower2/0, DCPower2/1"],
+        expected_session_names2=["niDCPower-DCPower2/0, DCPower2/1"]
     ),
 ]
 
@@ -197,6 +214,7 @@ _SMU_MULTI_SESSION_CONFIGURATIONS = [
         ["DCPower1/0, DCPower1/1", "DCPower1/2, DCPower1/3"],
         ["DCPower1/0, DCPower1/1", "DCPower1/2, DCPower1/3"],
         ["DCPower1/0, DCPower1/1", "DCPower1/2, DCPower1/3"],
+        expected_session_names2=["niDCPower-DCPower1/0, DCPower1/1", "niDCPower-DCPower1/2, DCPower1/3"]
     ),
     Configuration(
         "2Smu2ChannelGroup2Pin2Site.pinmap",
@@ -205,6 +223,7 @@ _SMU_MULTI_SESSION_CONFIGURATIONS = [
         ["DCPower1/0, DCPower1/1", "DCPower2/0, DCPower2/1"],
         ["DCPower1/0, DCPower1/1", "DCPower2/0, DCPower2/1"],
         ["DCPower1/0, DCPower1/1", "DCPower2/0, DCPower2/1"],
+        expected_session_names2=["niDCPower-DCPower1/0, DCPower1/1", "niDCPower-DCPower2/0, DCPower2/1"]
     ),
 ]
 
@@ -248,7 +267,7 @@ def test___multi_session___measure___reserves_multiple_sessions(
 
     outputs = _measure(stub_v2, pin_map_context, configurations)
 
-    assert outputs.session_names == configuration.expected_session_names
+    assert outputs.session_names == configuration.expected_session_names or outputs.session_names == configuration.expected_session_names2
     assert outputs.resource_names == configuration.expected_resource_names
     assert outputs.channel_lists == configuration.expected_channel_lists
 

--- a/packages/service/tests/acceptance/test_session_management.py
+++ b/packages/service/tests/acceptance/test_session_management.py
@@ -175,7 +175,7 @@ _SMU_SINGLE_SESSION_CONFIGURATIONS = [
         ["DCPower1/2, DCPower1/3"],
         ["DCPower1/2, DCPower1/3"],
         ["DCPower1/2, DCPower1/3"],
-        expected_session_names2=["niDCPower-DCPower1/2, DCPower1/3"]
+        expected_session_names2=["niDCPower-DCPower1/2, DCPower1/3"],
     ),
     Configuration(
         "2Smu2ChannelGroup2Pin2Site.pinmap",
@@ -202,7 +202,7 @@ _SMU_SINGLE_SESSION_CONFIGURATIONS = [
         ["DCPower2/0, DCPower2/1"],
         ["DCPower2/0, DCPower2/1"],
         ["DCPower2/0, DCPower2/1"],
-        expected_session_names2=["niDCPower-DCPower2/0, DCPower2/1"]
+        expected_session_names2=["niDCPower-DCPower2/0, DCPower2/1"],
     ),
 ]
 
@@ -214,7 +214,10 @@ _SMU_MULTI_SESSION_CONFIGURATIONS = [
         ["DCPower1/0, DCPower1/1", "DCPower1/2, DCPower1/3"],
         ["DCPower1/0, DCPower1/1", "DCPower1/2, DCPower1/3"],
         ["DCPower1/0, DCPower1/1", "DCPower1/2, DCPower1/3"],
-        expected_session_names2=["niDCPower-DCPower1/0, DCPower1/1", "niDCPower-DCPower1/2, DCPower1/3"]
+        expected_session_names2=[
+            "niDCPower-DCPower1/0, DCPower1/1",
+            "niDCPower-DCPower1/2, DCPower1/3",
+        ],
     ),
     Configuration(
         "2Smu2ChannelGroup2Pin2Site.pinmap",
@@ -223,7 +226,10 @@ _SMU_MULTI_SESSION_CONFIGURATIONS = [
         ["DCPower1/0, DCPower1/1", "DCPower2/0, DCPower2/1"],
         ["DCPower1/0, DCPower1/1", "DCPower2/0, DCPower2/1"],
         ["DCPower1/0, DCPower1/1", "DCPower2/0, DCPower2/1"],
-        expected_session_names2=["niDCPower-DCPower1/0, DCPower1/1", "niDCPower-DCPower2/0, DCPower2/1"]
+        expected_session_names2=[
+            "niDCPower-DCPower1/0, DCPower1/1",
+            "niDCPower-DCPower2/0, DCPower2/1",
+        ],
     ),
 ]
 
@@ -267,7 +273,10 @@ def test___multi_session___measure___reserves_multiple_sessions(
 
     outputs = _measure(stub_v2, pin_map_context, configurations)
 
-    assert outputs.session_names == configuration.expected_session_names or outputs.session_names == configuration.expected_session_names2
+    assert (
+        outputs.session_names == configuration.expected_session_names
+        or outputs.session_names == configuration.expected_session_names2
+    )
     assert outputs.resource_names == configuration.expected_resource_names
     assert outputs.channel_lists == configuration.expected_channel_lists
 

--- a/packages/service/tests/integration/session_management/test_nidcpower_reservation.py
+++ b/packages/service/tests/integration/session_management/test_nidcpower_reservation.py
@@ -26,7 +26,7 @@ def test___single_session_reserved___initialize_nidcpower_session___creates_sing
         session_info = stack.enter_context(reservation.initialize_nidcpower_session())
 
         assert session_info.session is not None
-        assert session_info.session_name == "DCPower1/0"
+        assert session_info.session_name == "DCPower1/0" or session_info.session_name == "niDCPower-DCPower1/0"
 
 
 def test___multiple_sessions_reserved___initialize_nidcpower_sessions___creates_multiple_sessions(
@@ -34,7 +34,8 @@ def test___multiple_sessions_reserved___initialize_nidcpower_sessions___creates_
     session_management_client: SessionManagementClient,
 ) -> None:
     pin_names = ["Pin1", "Pin2"]
-    nidcpower_resource = ["DCPower1/0", "DCPower1/2"]
+    nidcpower_resources = ["DCPower1/0", "DCPower1/2"]
+    nidcpower_resources2 = ["niDCPower-DCPower1/0", "niDCPower-DCPower1/2"]
     with ExitStack() as stack:
         reservation = stack.enter_context(
             session_management_client.reserve_sessions(pin_map_context, pin_names)
@@ -43,12 +44,19 @@ def test___multiple_sessions_reserved___initialize_nidcpower_sessions___creates_
         session_infos = stack.enter_context(reservation.initialize_nidcpower_sessions())
 
         assert all([session_info.session is not None for session_info in session_infos])
-        assert all(
+        matches1 = all(
             [
                 session_info.session_name == expected_resource
-                for session_info, expected_resource in zip(session_infos, nidcpower_resource)
+                for session_info, expected_resource in zip(session_infos, nidcpower_resources)
             ]
         )
+        matches2 = all(
+            [
+                session_info.session_name == expected_resource
+                for session_info, expected_resource in zip(session_infos, nidcpower_resources2)
+            ]
+        )
+        assert matches1 or matches2
 
 
 def test___session_created___get_nidcpower_connection___returns_connection(

--- a/packages/service/tests/integration/session_management/test_nidcpower_reservation.py
+++ b/packages/service/tests/integration/session_management/test_nidcpower_reservation.py
@@ -26,7 +26,10 @@ def test___single_session_reserved___initialize_nidcpower_session___creates_sing
         session_info = stack.enter_context(reservation.initialize_nidcpower_session())
 
         assert session_info.session is not None
-        assert session_info.session_name == "DCPower1/0" or session_info.session_name == "niDCPower-DCPower1/0"
+        assert (
+            session_info.session_name == "DCPower1/0"
+            or session_info.session_name == "niDCPower-DCPower1/0"
+        )
 
 
 def test___multiple_sessions_reserved___initialize_nidcpower_sessions___creates_multiple_sessions(

--- a/packages/service/tests/integration/session_management/test_nidigital_reservation.py
+++ b/packages/service/tests/integration/session_management/test_nidigital_reservation.py
@@ -25,7 +25,7 @@ def test___single_session_reserved___initialize_nidigital_session___creates_sing
         session_info = stack.enter_context(reservation.initialize_nidigital_session())
 
         assert session_info.session is not None
-        assert session_info.session_name == "DigitalPattern1"
+        assert session_info.session_name == "DigitalPattern1" or session_info.session_name == "niDigitalPattern-DigitalPattern1"
 
 
 def test___multiple_sessions_reserved___initialize_nidigital_sessions___creates_multiple_sessions(

--- a/packages/service/tests/integration/session_management/test_nidigital_reservation.py
+++ b/packages/service/tests/integration/session_management/test_nidigital_reservation.py
@@ -25,7 +25,10 @@ def test___single_session_reserved___initialize_nidigital_session___creates_sing
         session_info = stack.enter_context(reservation.initialize_nidigital_session())
 
         assert session_info.session is not None
-        assert session_info.session_name == "DigitalPattern1" or session_info.session_name == "niDigitalPattern-DigitalPattern1"
+        assert (
+            session_info.session_name == "DigitalPattern1"
+            or session_info.session_name == "niDigitalPattern-DigitalPattern1"
+        )
 
 
 def test___multiple_sessions_reserved___initialize_nidigital_sessions___creates_multiple_sessions(

--- a/packages/service/tests/integration/session_management/test_nidmm_reservation.py
+++ b/packages/service/tests/integration/session_management/test_nidmm_reservation.py
@@ -26,7 +26,7 @@ def test___single_session_reserved___initialize_nidmm_session___creates_single_s
         session_info = stack.enter_context(reservation.initialize_nidmm_session())
 
         assert session_info.session is not None
-        assert session_info.session_name == "DMM1"
+        assert session_info.session_name == "DMM1" or session_info.session_name == "niDMM-DMM1"
 
 
 def test___multiple_sessions_reserved___initialize_nidmm_sessions___creates_multiple_sessions(
@@ -35,6 +35,7 @@ def test___multiple_sessions_reserved___initialize_nidmm_sessions___creates_mult
 ) -> None:
     pin_names = ["Pin1", "Pin2"]
     nidmm_resource = ["DMM1", "DMM2"]
+    nidmm_resource2 = ["niDMM-DMM1", "niDMM-DMM2"]
     with ExitStack() as stack:
         reservation = stack.enter_context(
             session_management_client.reserve_sessions(pin_map_context, pin_names)
@@ -43,12 +44,19 @@ def test___multiple_sessions_reserved___initialize_nidmm_sessions___creates_mult
         session_infos = stack.enter_context(reservation.initialize_nidmm_sessions())
 
         assert all([session_info.session is not None for session_info in session_infos])
-        assert all(
+        matches1 = all(
             [
                 session_info.session_name == expected_resource
                 for session_info, expected_resource in zip(session_infos, nidmm_resource)
             ]
         )
+        matches2 = all(
+            [
+                session_info.session_name == expected_resource
+                for session_info, expected_resource in zip(session_infos, nidmm_resource2)
+            ]
+        )
+        assert matches1 or matches2
 
 
 def test___session_created___get_nidmm_connection___returns_connection(

--- a/packages/service/tests/integration/session_management/test_nifgen_reservation.py
+++ b/packages/service/tests/integration/session_management/test_nifgen_reservation.py
@@ -42,8 +42,14 @@ def test___multiple_sessions_reserved___initialize_nifgen_sessions___creates_mul
         session_infos = stack.enter_context(reservation.initialize_nifgen_sessions())
 
         assert all([session_info.session is not None for session_info in session_infos])
-        assert session_infos[0].session_name == "FGEN1" or session_infos[0].session_name == "niFGen-FGEN1"
-        assert session_infos[1].session_name == "FGEN2" or session_infos[1].session_name == "niFGen-FGEN2"
+        assert (
+            session_infos[0].session_name == "FGEN1"
+            or session_infos[0].session_name == "niFGen-FGEN1"
+        )
+        assert (
+            session_infos[1].session_name == "FGEN2"
+            or session_infos[1].session_name == "niFGen-FGEN2"
+        )
 
 
 def test___session_created___get_nifgen_connection___returns_connection(

--- a/packages/service/tests/integration/session_management/test_nifgen_reservation.py
+++ b/packages/service/tests/integration/session_management/test_nifgen_reservation.py
@@ -26,7 +26,7 @@ def test___single_session_reserved___initialize_nifgen_session___creates_single_
         session_info = stack.enter_context(reservation.initialize_nifgen_session())
 
         assert session_info.session is not None
-        assert session_info.session_name == "FGEN1"
+        assert session_info.session_name == "FGEN1" or session_info.session_name == "niFGen-FGEN1"
 
 
 def test___multiple_sessions_reserved___initialize_nifgen_sessions___creates_multiple_sessions(
@@ -42,8 +42,8 @@ def test___multiple_sessions_reserved___initialize_nifgen_sessions___creates_mul
         session_infos = stack.enter_context(reservation.initialize_nifgen_sessions())
 
         assert all([session_info.session is not None for session_info in session_infos])
-        assert session_infos[0].session_name == "FGEN1"
-        assert session_infos[1].session_name == "FGEN2"
+        assert session_infos[0].session_name == "FGEN1" or session_infos[0].session_name == "niFGen-FGEN1"
+        assert session_infos[1].session_name == "FGEN2" or session_infos[1].session_name == "niFGen-FGEN2"
 
 
 def test___session_created___get_nifgen_connection___returns_connection(

--- a/packages/service/tests/integration/session_management/test_niscope_reservation.py
+++ b/packages/service/tests/integration/session_management/test_niscope_reservation.py
@@ -26,7 +26,7 @@ def test___single_session_reserved___initialize_niscope_session___creates_single
         session_info = stack.enter_context(reservation.initialize_niscope_session())
 
         assert session_info.session is not None
-        assert session_info.session_name == "SCOPE1"
+        assert session_info.session_name == "SCOPE1" or session_info.session_name == "niScope-SCOPE1"
 
 
 def test___multiple_sessions_reserved___initialize_niscope_sessions___creates_multiple_sessions(
@@ -42,8 +42,8 @@ def test___multiple_sessions_reserved___initialize_niscope_sessions___creates_mu
         session_infos = stack.enter_context(reservation.initialize_niscope_sessions())
 
         assert all([session_info.session is not None for session_info in session_infos])
-        assert session_infos[0].session_name == "SCOPE1"
-        assert session_infos[1].session_name == "SCOPE2"
+        assert session_infos[0].session_name == "SCOPE1" or session_infos[0].session_name == "niScope-SCOPE1"
+        assert session_infos[1].session_name == "SCOPE2" or session_infos[1].session_name == "niScope-SCOPE2"
 
 
 def test___session_created___get_niscope_connection___returns_connection(

--- a/packages/service/tests/integration/session_management/test_niscope_reservation.py
+++ b/packages/service/tests/integration/session_management/test_niscope_reservation.py
@@ -26,7 +26,9 @@ def test___single_session_reserved___initialize_niscope_session___creates_single
         session_info = stack.enter_context(reservation.initialize_niscope_session())
 
         assert session_info.session is not None
-        assert session_info.session_name == "SCOPE1" or session_info.session_name == "niScope-SCOPE1"
+        assert (
+            session_info.session_name == "SCOPE1" or session_info.session_name == "niScope-SCOPE1"
+        )
 
 
 def test___multiple_sessions_reserved___initialize_niscope_sessions___creates_multiple_sessions(
@@ -42,8 +44,14 @@ def test___multiple_sessions_reserved___initialize_niscope_sessions___creates_mu
         session_infos = stack.enter_context(reservation.initialize_niscope_sessions())
 
         assert all([session_info.session is not None for session_info in session_infos])
-        assert session_infos[0].session_name == "SCOPE1" or session_infos[0].session_name == "niScope-SCOPE1"
-        assert session_infos[1].session_name == "SCOPE2" or session_infos[1].session_name == "niScope-SCOPE2"
+        assert (
+            session_infos[0].session_name == "SCOPE1"
+            or session_infos[0].session_name == "niScope-SCOPE1"
+        )
+        assert (
+            session_infos[1].session_name == "SCOPE2"
+            or session_infos[1].session_name == "niScope-SCOPE2"
+        )
 
 
 def test___session_created___get_niscope_connection___returns_connection(

--- a/packages/service/tests/integration/session_management/test_niswitch_reservation.py
+++ b/packages/service/tests/integration/session_management/test_niswitch_reservation.py
@@ -26,7 +26,7 @@ def test___single_session_reserved___initialize_niswitch_session___creates_singl
         session_info = stack.enter_context(reservation.initialize_niswitch_session())
 
         assert session_info.session is not None
-        assert session_info.session_name == "RelayDriver1"
+        assert session_info.session_name == "RelayDriver1" or session_info.session_name == "niRelayDriver-RelayDriver1"
 
 
 def test___multiple_sessions_reserved___initialize_niswitch_sessions___creates_multiple_sessions(

--- a/packages/service/tests/integration/session_management/test_niswitch_reservation.py
+++ b/packages/service/tests/integration/session_management/test_niswitch_reservation.py
@@ -26,7 +26,10 @@ def test___single_session_reserved___initialize_niswitch_session___creates_singl
         session_info = stack.enter_context(reservation.initialize_niswitch_session())
 
         assert session_info.session is not None
-        assert session_info.session_name == "RelayDriver1" or session_info.session_name == "niRelayDriver-RelayDriver1"
+        assert (
+            session_info.session_name == "RelayDriver1"
+            or session_info.session_name == "niRelayDriver-RelayDriver1"
+        )
 
 
 def test___multiple_sessions_reserved___initialize_niswitch_sessions___creates_multiple_sessions(


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-plugin-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

I found that around 30 of the service tests fail when I have InstrumentStudio 2025Q3 installed locally. The problem was that the session management service started appending the driver name in front of the resource name for the session in Q3. For example, the session name became 'niDCPower-DCPower1/0' instead of just 'DCPower1/0'. The test machines are still using an older version of InstrumentStudio, so until we upgrade that, we have to allow for both versions.

### Why should this Pull Request be merged?

Allows either version of the session name and tests can pass locally and on the test machines.

### What testing has been done?

Ran the tests locally with InstrumentStudio 2025Q3. Test machines will validate older InstrumentStudio.