### PR TITLE
Bump versions to 3.0.0-dev0

### DIFF
--- a/examples/nidaqmx_analog_input/pyproject.toml
+++ b/examples/nidaqmx_analog_input/pyproject.toml
@@ -17,7 +17,7 @@ mypy = ">=1.0"
 types-grpcio = ">=1.0"
 # Uncomment to use prerelease dependencies.
 # nidaqmx = { git = "https://github.com/ni/nidaqmx-python.git", branch = "master", extras = ["grpc"] }
-ni-measurement-plugin-sdk-service = {path = "../../packages/service", develop = true}
+# ni-measurement-plugin-sdk-service = {path = "../../packages/service", develop = true}
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/examples/nidcpower_source_dc_voltage/pyproject.toml
+++ b/examples/nidcpower_source_dc_voltage/pyproject.toml
@@ -18,7 +18,7 @@ mypy = ">=1.0"
 types-grpcio = ">=1.0"
 # Uncomment to use prerelease dependencies.
 # nidcpower = { git = "https://github.com/ni/nimi-python.git", subdirectory = "generated/nidcpower", extras = ["grpc"] }
-ni-measurement-plugin-sdk-service = {path = "../../packages/service", develop = true}
+# ni-measurement-plugin-sdk-service = {path = "../../packages/service", develop = true}
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/examples/nidcpower_source_dc_voltage_with_multiplexer/pyproject.toml
+++ b/examples/nidcpower_source_dc_voltage_with_multiplexer/pyproject.toml
@@ -20,7 +20,7 @@ types-grpcio = ">=1.0"
 # Uncomment to use prerelease dependencies.
 # nidcpower = { git = "https://github.com/ni/nimi-python.git", subdirectory = "generated/nidcpower", extras = ["grpc"] }
 # niswitch = { git = "https://github.com/ni/nimi-python.git", subdirectory = "generated/niswitch", extras = ["grpc"] }
-ni-measurement-plugin-sdk-service = {path = "../../packages/service", develop = true}
+# ni-measurement-plugin-sdk-service = {path = "../../packages/service", develop = true}
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/examples/nidigital_spi/pyproject.toml
+++ b/examples/nidigital_spi/pyproject.toml
@@ -18,7 +18,7 @@ mypy = ">=1.0"
 types-grpcio = ">=1.0"
 # Uncomment to use prerelease dependencies.
 # nidigital = { git = "https://github.com/ni/nimi-python.git", subdirectory = "generated/nidigital", extras = ["grpc"] }
-ni-measurement-plugin-sdk-service = {path = "../../packages/service", develop = true}
+# ni-measurement-plugin-sdk-service = {path = "../../packages/service", develop = true}
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/examples/nidmm_measurement/pyproject.toml
+++ b/examples/nidmm_measurement/pyproject.toml
@@ -18,7 +18,7 @@ mypy = ">=1.0"
 types-grpcio = ">=1.0"
 # Uncomment to use prerelease dependencies.
 # nidmm = { git = "https://github.com/ni/nimi-python.git", subdirectory = "generated/nidmm", extras = ["grpc"] }
-ni-measurement-plugin-sdk-service = {path = "../../packages/service", develop = true}
+# ni-measurement-plugin-sdk-service = {path = "../../packages/service", develop = true}
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/examples/nifgen_standard_function/pyproject.toml
+++ b/examples/nifgen_standard_function/pyproject.toml
@@ -18,7 +18,7 @@ mypy = ">=1.0"
 types-grpcio = ">=1.0"
 # Uncomment to use prerelease dependencies.
 # nifgen = { git = "https://github.com/ni/nimi-python.git", subdirectory = "generated/nifgen", extras = ["grpc"] }
-ni-measurement-plugin-sdk-service = {path = "../../packages/service", develop = true}
+# ni-measurement-plugin-sdk-service = {path = "../../packages/service", develop = true}
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/examples/niscope_acquire_waveform/pyproject.toml
+++ b/examples/niscope_acquire_waveform/pyproject.toml
@@ -18,7 +18,7 @@ mypy = ">=1.0"
 types-grpcio = ">=1.0"
 # Uncomment to use prerelease dependencies.
 # niscope = { git = "https://github.com/ni/nimi-python.git", subdirectory = "generated/niscope", extras = ["grpc"] }
-ni-measurement-plugin-sdk-service = {path = "../../packages/service", develop = true}
+# ni-measurement-plugin-sdk-service = {path = "../../packages/service", develop = true}
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/examples/niswitch_control_relays/pyproject.toml
+++ b/examples/niswitch_control_relays/pyproject.toml
@@ -18,7 +18,7 @@ mypy = ">=1.0"
 types-grpcio = ">=1.0"
 # Uncomment to use prerelease dependencies.
 # niswitch = { git = "https://github.com/ni/nimi-python.git", subdirectory = "generated/niswitch", extras = ["grpc"] }
-ni-measurement-plugin-sdk-service = {path = "../../packages/service", develop = true}
+# ni-measurement-plugin-sdk-service = {path = "../../packages/service", develop = true}
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/examples/sample_measurement/pyproject.toml
+++ b/examples/sample_measurement/pyproject.toml
@@ -19,7 +19,7 @@ grpcio-tools = "1.49.1"
 mypy-protobuf = "^3.6.0"
 types-protobuf = ">=4.21"
 # Uncomment to use prerelease dependencies.
-ni-measurement-plugin-sdk-service = {path = "../../packages/service", develop = true}
+# ni-measurement-plugin-sdk-service = {path = "../../packages/service", develop = true}
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/packages/generator/pyproject.toml
+++ b/packages/generator/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ni_measurement_plugin_sdk_generator"
-version = "2.4.0-dev3"
+version = "3.0.0-dev0"
 description = "Measurement Plug-In Code Generator for Python"
 authors = ["NI <opensource@ni.com>"]
 readme = "README.md"

--- a/packages/sdk/pyproject.toml
+++ b/packages/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ni_measurement_plugin_sdk"
-version = "2.4.0-dev3"
+version = "3.0.0-dev0"
 description = "Measurement Plug-In SDK for Python"
 authors = ["NI <opensource@ni.com>"]
 readme = "README.md"

--- a/packages/service/pyproject.toml
+++ b/packages/service/pyproject.toml
@@ -7,7 +7,7 @@ extend_exclude = '.tox/,*_pb2_grpc.py,*_pb2_grpc.pyi,*_pb2.py,*_pb2.pyi,ni_measu
 
 [tool.poetry]
 name = "ni_measurement_plugin_sdk_service"
-version = "2.4.0-dev3"
+version = "3.0.0-dev0"
 description = "Measurement Plug-In Support for Python"
 authors = ["NI <opensource@ni.com>"]
 readme = "README.md" # apply the repo readme to the package as well


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-plugin-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Bump versions in main for generator, sdk, and service to 3.0.0-dev0

### Why should this Pull Request be merged?

Distinguish from releases/2.4 branch, soon to be released. Bump major version since we've deprecated some code. Standard release process.

```
"After creating a new release branch, update pyproject.toml in the main branch to have the next pre-release version number.
For example, after creating releases/1.2, update pyproject.toml to specify version = "1.3.0-dev0".
This reduces confusion about which branch is which."
```

### What testing has been done?

PR