### PR TITLE
[Cherry pick from releases/3.0] Restore session_management module export

### DIFF
--- a/examples/game_of_life/pyproject.toml
+++ b/examples/game_of_life/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 
 [tool.poetry.dependencies]
 python = "^3.9"
-ni-measurement-plugin-sdk-service = {version = "^2.3.1"}
+ni-measurement-plugin-sdk-service = {version = ">=2.3.1,<4.0"}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 ni-protobuf-types = { version = ">=0.1.0dev2", allow-prereleases = true }
 

--- a/examples/nidaqmx_analog_input/pyproject.toml
+++ b/examples/nidaqmx_analog_input/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.9"
 nidaqmx = { version = ">=0.8.0", extras = ["grpc"] }
-ni-measurement-plugin-sdk-service = {version = "^2.3.1"}
+ni-measurement-plugin-sdk-service = {version = ">=2.3.1,<4.0"}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 
 [tool.poetry.group.dev.dependencies]

--- a/examples/nidcpower_source_dc_voltage/pyproject.toml
+++ b/examples/nidcpower_source_dc_voltage/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.9"
 nidcpower = { version = ">=1.4.4", extras = ["grpc"] }
-ni-measurement-plugin-sdk-service = {version = "^2.3.1"}
+ni-measurement-plugin-sdk-service = {version = ">=2.3.1,<4.0"}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 

--- a/examples/nidcpower_source_dc_voltage_with_multiplexer/pyproject.toml
+++ b/examples/nidcpower_source_dc_voltage_with_multiplexer/pyproject.toml
@@ -9,7 +9,7 @@ authors = ["National Instruments"]
 python = "^3.9"
 nidcpower = { version = ">=1.4.4", extras = ["grpc"] }
 niswitch = { version = ">=1.4.4", extras = ["grpc"] }
-ni-measurement-plugin-sdk-service = {version = "^2.3.1"}
+ni-measurement-plugin-sdk-service = {version = ">=2.3.1,<4.0"}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 

--- a/examples/nidigital_spi/pyproject.toml
+++ b/examples/nidigital_spi/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.9"
 nidigital = { version = ">=1.4.4", extras = ["grpc"] }
-ni-measurement-plugin-sdk-service = {version = "^2.3.1"}
+ni-measurement-plugin-sdk-service = {version = ">=2.3.1,<4.0"}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 

--- a/examples/nidigital_spi/teststand_nidigital.py
+++ b/examples/nidigital_spi/teststand_nidigital.py
@@ -8,12 +8,10 @@ from ni_measurement_plugin_sdk_service.discovery import DiscoveryClient
 from ni_measurement_plugin_sdk_service.grpc.channelpool import GrpcChannelPool
 from ni_measurement_plugin_sdk_service.session_management import (
     INSTRUMENT_TYPE_NI_DIGITAL_PATTERN,
+    MultiSessionReservation,
     PinMapContext,
     SessionInitializationBehavior,
     SessionManagementClient,
-)
-from ni_measurement_plugin_sdk_service.session_management._reservation import (
-    MultiSessionReservation,
 )
 
 

--- a/examples/nidmm_measurement/pyproject.toml
+++ b/examples/nidmm_measurement/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.9"
 nidmm = { version = ">=1.4.4", extras = ["grpc"] }
-ni-measurement-plugin-sdk-service = {version = "^2.3.1"}
+ni-measurement-plugin-sdk-service = {version = ">=2.3.1,<4.0"}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 

--- a/examples/nifgen_standard_function/pyproject.toml
+++ b/examples/nifgen_standard_function/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.9"
 nifgen = { version = ">=1.4.4", extras = ["grpc"] }
-ni-measurement-plugin-sdk-service = {version = "^2.3.1"}
+ni-measurement-plugin-sdk-service = {version = ">=2.3.1,<4.0"}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 

--- a/examples/niscope_acquire_waveform/pyproject.toml
+++ b/examples/niscope_acquire_waveform/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.9"
 niscope = { version = ">=1.4.4", extras = ["grpc"] }
-ni-measurement-plugin-sdk-service = {version = "^2.3.1"}
+ni-measurement-plugin-sdk-service = {version = ">=2.3.1,<4.0"}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 

--- a/examples/niswitch_control_relays/pyproject.toml
+++ b/examples/niswitch_control_relays/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.9"
 niswitch = { version = ">=1.4.4", extras = ["grpc"] }
-ni-measurement-plugin-sdk-service = {version = "^2.3.1"}
+ni-measurement-plugin-sdk-service = {version = ">=2.3.1,<4.0"}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 

--- a/examples/nivisa_dmm_measurement/pyproject.toml
+++ b/examples/nivisa_dmm_measurement/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 
 [tool.poetry.dependencies]
 python = "^3.9"
-ni-measurement-plugin-sdk-service = {version = "^2.3.1"}
+ni-measurement-plugin-sdk-service = {version = ">=2.3.1,<4.0"}
 PyVISA = "^1.13.0"
 PyVISA-sim = "^0.5.1"
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558

--- a/examples/nivisa_dmm_measurement/teststand_nivisa_dmm.py
+++ b/examples/nivisa_dmm_measurement/teststand_nivisa_dmm.py
@@ -11,10 +11,8 @@ from ni_measurement_plugin_sdk_service.discovery import DiscoveryClient
 from ni_measurement_plugin_sdk_service.grpc.channelpool import GrpcChannelPool
 from ni_measurement_plugin_sdk_service.session_management import (
     PinMapContext,
-    SessionManagementClient,
-)
-from ni_measurement_plugin_sdk_service.session_management._types import (
     SessionInitializationBehavior,
+    SessionManagementClient,
 )
 
 # Search for the `.env` file starting with this code module's parent directory.

--- a/examples/output_voltage_measurement/pyproject.toml
+++ b/examples/output_voltage_measurement/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 
 [tool.poetry.dependencies]
 python = "^3.9"
-ni-measurement-plugin-sdk-service = {version = "^2.3.1"}
+ni-measurement-plugin-sdk-service = {version = ">=2.3.1,<4.0"}
 PyVISA = "^1.13.0"
 PyVISA-sim = "^0.5.1"
 nidcpower = { version = ">=1.4.4", extras = ["grpc"] }

--- a/examples/output_voltage_measurement/teststand_nivisa_dmm.py
+++ b/examples/output_voltage_measurement/teststand_nivisa_dmm.py
@@ -11,10 +11,8 @@ from ni_measurement_plugin_sdk_service.discovery import DiscoveryClient
 from ni_measurement_plugin_sdk_service.grpc.channelpool import GrpcChannelPool
 from ni_measurement_plugin_sdk_service.session_management import (
     PinMapContext,
-    SessionManagementClient,
-)
-from ni_measurement_plugin_sdk_service.session_management._types import (
     SessionInitializationBehavior,
+    SessionManagementClient,
 )
 
 # Search for the `.env` file starting with this code module's parent directory.

--- a/examples/sample_measurement/pyproject.toml
+++ b/examples/sample_measurement/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 
 [tool.poetry.dependencies]
 python = "^3.9"
-ni-measurement-plugin-sdk-service = {version = "^2.3.1"}
+ni-measurement-plugin-sdk-service = {version = ">=2.3.1,<4.0"}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 ni-protobuf-types = { version = ">=0.1.0dev2", allow-prereleases = true }
 

--- a/packages/service/ni_measurement_plugin_sdk_service/__init__.py
+++ b/packages/service/ni_measurement_plugin_sdk_service/__init__.py
@@ -4,10 +4,12 @@ import logging
 
 from ni.measurementlink.discovery.v1.client import ServiceInfo
 
+from ni_measurement_plugin_sdk_service import session_management
 from ni_measurement_plugin_sdk_service.measurement.info import DataType, MeasurementInfo
 from ni_measurement_plugin_sdk_service.measurement.service import MeasurementService
 
 __all__ = [
+    "session_management",
     "DataType",
     "MeasurementInfo",
     "ServiceInfo",

--- a/packages/service/ni_measurement_plugin_sdk_service/session_management/_reservation.py
+++ b/packages/service/ni_measurement_plugin_sdk_service/session_management/_reservation.py
@@ -1,3 +1,13 @@
-from ni.measurementlink.sessionmanagement.v1.client import MultiSessionReservation
+from ni.measurementlink.sessionmanagement.v1.client import (
+    BaseReservation,
+    MultiplexerSessionContainer,
+    MultiSessionReservation,
+    SingleSessionReservation,
+)
 
-__all__ = ["MultiSessionReservation"]
+__all__ = [
+    "BaseReservation",
+    "MultiplexerSessionContainer",
+    "MultiSessionReservation",
+    "SingleSessionReservation",
+]

--- a/packages/service/ni_measurement_plugin_sdk_service/session_management/_types.py
+++ b/packages/service/ni_measurement_plugin_sdk_service/session_management/_types.py
@@ -1,0 +1,25 @@
+from ni.measurementlink.sessionmanagement.v1.client import (
+    ChannelMapping,
+    Connection,
+    MultiplexerSessionInformation,
+    PinMapContext,
+    SessionInformation,
+    SessionInitializationBehavior,
+    TypedConnection,
+    TypedConnectionWithMultiplexer,
+    TypedMultiplexerSessionInformation,
+    TypedSessionInformation,
+)
+
+__all__ = [
+    "ChannelMapping",
+    "Connection",
+    "MultiplexerSessionInformation",
+    "PinMapContext",
+    "SessionInformation",
+    "SessionInitializationBehavior",
+    "TypedConnection",
+    "TypedConnectionWithMultiplexer",
+    "TypedMultiplexerSessionInformation",
+    "TypedSessionInformation",
+]


### PR DESCRIPTION
Cherry pick from #1250

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-plugin-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Adds back in the session_management to __all__ in the ni_measurement_plugin_sdk_service. This was removed when we started consuming packages from ni-apis-python (see #1220), but not restored with #1228.

Also updating the examples pyproject.toml to allow version 3.0.

### Why should this Pull Request be merged?

Examples are broken when upgrading to the 3.0.0 version.

### What testing has been done?

Installed ni_dcpower_source_voltage example with a local 3.0.1 and ensured it ran correctly.